### PR TITLE
ACA-126 - replaced internal ES call with external CaseDetailsById

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/managecase/fixtures/WiremockFixtures.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/managecase/fixtures/WiremockFixtures.java
@@ -25,7 +25,6 @@ import uk.gov.hmcts.reform.managecase.client.datastore.CaseUserRolesRequest;
 import uk.gov.hmcts.reform.managecase.client.datastore.StartEventResource;
 import uk.gov.hmcts.reform.managecase.client.datastore.model.CaseUpdateViewEvent;
 import uk.gov.hmcts.reform.managecase.client.datastore.model.CaseViewResource;
-import uk.gov.hmcts.reform.managecase.client.datastore.model.elasticsearch.CaseSearchResultViewResource;
 import uk.gov.hmcts.reform.managecase.client.definitionstore.model.CaseRole;
 import uk.gov.hmcts.reform.managecase.client.definitionstore.model.ChallengeQuestionsResult;
 import uk.gov.hmcts.reform.managecase.client.prd.FindUsersByOrganisationResponse;
@@ -46,7 +45,6 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static org.assertj.core.util.Lists.list;
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static uk.gov.hmcts.reform.managecase.client.datastore.DataStoreApiClient.CASE_USERS;
-import static uk.gov.hmcts.reform.managecase.client.datastore.DataStoreApiClient.INTERNAL_SEARCH_CASES;
 import static uk.gov.hmcts.reform.managecase.client.datastore.DataStoreApiClient.SEARCH_CASES;
 
 @SuppressWarnings({"PMD.TooManyMethods", "PMD.ExcessiveImports"})
@@ -144,18 +142,6 @@ public class WiremockFixtures {
                     .willReturn(aResponse()
                                     .withStatus(HTTP_OK)
                                     .withBody(getJsonString(new CaseUserRoleResource(caseUserRoles)))
-                                    .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)));
-    }
-
-    public static void stubGetCaseInternalES(String caseTypeId,
-                                             String searchQuery,
-                                             CaseSearchResultViewResource resource) {
-        stubFor(WireMock.post(urlEqualTo(INTERNAL_SEARCH_CASES + "?ctid=" + caseTypeId))
-                    .withRequestBody(equalToJson(searchQuery))
-                    .withHeader(AUTHORIZATION, equalTo(SYS_USER_TOKEN))
-                    .withHeader(SERVICE_AUTHORIZATION, equalTo(S2S_TOKEN))
-                    .willReturn(aResponse()
-                                    .withStatus(HTTP_OK).withBody(getJsonString(resource))
                                     .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/managecase/client/datastore/CaseDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/client/datastore/CaseDetails.java
@@ -50,6 +50,7 @@ public class CaseDetails {
     private String state;
 
     @JsonProperty("case_type_id")
+    @JsonAlias("case_type") // alias to match with data-store V2 external api GetCase
     private String caseTypeId;
 
     @JsonProperty("case_data")

--- a/src/main/java/uk/gov/hmcts/reform/managecase/client/datastore/CaseDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/client/datastore/CaseDetails.java
@@ -19,6 +19,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static uk.gov.hmcts.reform.managecase.client.datastore.model.CaseFieldPathUtils.getNestedCaseFieldByPath;
+
 @Data
 @Builder
 @AllArgsConstructor
@@ -103,4 +105,23 @@ public class CaseDetails {
         }
         return null;
     }
+
+    public List<JsonNode> findCorNodes() {
+        return getData().values().stream()
+            .map(node -> node.findParents(ORGANISATION_TO_ADD))
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
+    }
+
+    public boolean hasCaseRoleId() {
+        return getData().values().stream()
+            .map(node -> node.findPath(CASE_ROLE_ID))
+            .anyMatch(node -> !node.isMissingNode() && !node.isNull());
+    }
+
+    public String getFieldValue(String fieldId) {
+        JsonNode fieldNode = getNestedCaseFieldByPath(data, fieldId);
+        return fieldNode == null || fieldNode.isNull() ? null : fieldNode.asText();
+    }
+
 }

--- a/src/main/java/uk/gov/hmcts/reform/managecase/domain/NoCRequestDetails.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/domain/NoCRequestDetails.java
@@ -3,8 +3,8 @@ package uk.gov.hmcts.reform.managecase.domain;
 import lombok.Builder;
 import lombok.Data;
 import uk.gov.hmcts.reform.managecase.api.payload.VerifyNoCAnswersResponse;
+import uk.gov.hmcts.reform.managecase.client.datastore.CaseDetails;
 import uk.gov.hmcts.reform.managecase.client.datastore.model.CaseViewResource;
-import uk.gov.hmcts.reform.managecase.client.datastore.model.elasticsearch.SearchResultViewItem;
 import uk.gov.hmcts.reform.managecase.client.definitionstore.model.ChallengeQuestionsResult;
 
 @Data
@@ -13,7 +13,7 @@ public class NoCRequestDetails {
 
     private CaseViewResource caseViewResource;
     private OrganisationPolicy organisationPolicy;
-    private SearchResultViewItem searchResultViewItem;
+    private CaseDetails caseDetails;
     private ChallengeQuestionsResult challengeQuestionsResult;
 
     public VerifyNoCAnswersResponse toVerifyNoCAnswersResponse(String status) {

--- a/src/main/java/uk/gov/hmcts/reform/managecase/service/noc/ChallengeAnswerValidator.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/service/noc/ChallengeAnswerValidator.java
@@ -1,7 +1,7 @@
 package uk.gov.hmcts.reform.managecase.service.noc;
 
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.managecase.client.datastore.model.elasticsearch.SearchResultViewItem;
+import uk.gov.hmcts.reform.managecase.client.datastore.CaseDetails;
 import uk.gov.hmcts.reform.managecase.client.definitionstore.model.ChallengeAnswer;
 import uk.gov.hmcts.reform.managecase.client.definitionstore.model.ChallengeQuestion;
 import uk.gov.hmcts.reform.managecase.client.definitionstore.model.ChallengeQuestionsResult;
@@ -25,11 +25,11 @@ public class ChallengeAnswerValidator {
 
     public String getMatchingCaseRole(ChallengeQuestionsResult challengeQuestions,
                                       List<SubmittedChallengeAnswer> submittedAnswers,
-                                      SearchResultViewItem caseResult) {
+                                      CaseDetails caseDetails) {
         validateNumberOfAnswers(submittedAnswers, challengeQuestions);
 
         Map<String, Integer> caseRoleCorrectAnswers =
-            getCaseRoleCorrectAnswers(submittedAnswers, challengeQuestions, caseResult);
+            getCaseRoleCorrectAnswers(submittedAnswers, challengeQuestions, caseDetails);
 
         return getMatchingCaseRole(caseRoleCorrectAnswers, challengeQuestions);
     }
@@ -53,14 +53,14 @@ public class ChallengeAnswerValidator {
 
     private Map<String, Integer> getCaseRoleCorrectAnswers(List<SubmittedChallengeAnswer> answers,
                                                            ChallengeQuestionsResult challengeQuestions,
-                                                           SearchResultViewItem caseResult) {
+                                                           CaseDetails caseDetails) {
         Map<String, Integer> caseRoleCorrectAnswers = new HashMap<>();
         challengeQuestions.getQuestions().forEach(question -> {
             String submittedAnswer = getSubmittedAnswerForQuestion(answers, question.getQuestionId()).getValue();
 
             question.getAnswers().forEach(answer -> {
                 List<String> acceptedValues = answer.getFieldIds().stream()
-                    .map(caseResult::getFieldValue)
+                    .map(caseDetails::getFieldValue)
                     .collect(toList());
 
                 if (isMatchingAnswerFound(question, submittedAnswer, acceptedValues)) {

--- a/src/main/java/uk/gov/hmcts/reform/managecase/service/noc/VerifyNoCAnswersService.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/service/noc/VerifyNoCAnswersService.java
@@ -3,13 +3,15 @@ package uk.gov.hmcts.reform.managecase.service.noc;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.hmcts.reform.managecase.api.payload.VerifyNoCAnswersRequest;
-import uk.gov.hmcts.reform.managecase.client.datastore.model.elasticsearch.SearchResultViewItem;
+import uk.gov.hmcts.reform.managecase.client.datastore.CaseDetails;
 import uk.gov.hmcts.reform.managecase.domain.NoCRequestDetails;
 import uk.gov.hmcts.reform.managecase.domain.Organisation;
 import uk.gov.hmcts.reform.managecase.domain.OrganisationPolicy;
 import uk.gov.hmcts.reform.managecase.repository.PrdRepository;
+import uk.gov.hmcts.reform.managecase.util.JacksonUtils;
 
 import javax.validation.ValidationException;
+import java.util.Optional;
 
 @Service
 public class VerifyNoCAnswersService {
@@ -17,26 +19,28 @@ public class VerifyNoCAnswersService {
     private final NoticeOfChangeQuestions noticeOfChangeQuestions;
     private final ChallengeAnswerValidator challengeAnswerValidator;
     private final PrdRepository prdRepository;
+    private final JacksonUtils jacksonUtils;
 
     @Autowired
     public VerifyNoCAnswersService(NoticeOfChangeQuestions noticeOfChangeQuestions,
                                    ChallengeAnswerValidator challengeAnswerValidator,
-                                   PrdRepository prdRepository) {
+                                   PrdRepository prdRepository, JacksonUtils jacksonUtils) {
         this.noticeOfChangeQuestions = noticeOfChangeQuestions;
         this.challengeAnswerValidator = challengeAnswerValidator;
         this.prdRepository = prdRepository;
+        this.jacksonUtils = jacksonUtils;
     }
 
     public NoCRequestDetails verifyNoCAnswers(VerifyNoCAnswersRequest verifyNoCAnswersRequest) {
         String caseId = verifyNoCAnswersRequest.getCaseId();
         NoCRequestDetails noCRequestDetails = noticeOfChangeQuestions.challengeQuestions(caseId);
-        SearchResultViewItem caseResult = noCRequestDetails.getSearchResultViewItem();
+        CaseDetails caseDetails = noCRequestDetails.getCaseDetails();
 
         String caseRoleId = challengeAnswerValidator
             .getMatchingCaseRole(noCRequestDetails.getChallengeQuestionsResult(),
-                verifyNoCAnswersRequest.getAnswers(), caseResult);
+                verifyNoCAnswersRequest.getAnswers(), caseDetails);
 
-        OrganisationPolicy organisationPolicy = caseResult.findOrganisationPolicyForRole(caseRoleId)
+        OrganisationPolicy organisationPolicy = findPolicy(caseDetails, caseRoleId)
             .orElseThrow(() -> new ValidationException(String.format(
                 "No OrganisationPolicy exists on the case for the case role '%s'", caseRoleId)));
 
@@ -53,5 +57,12 @@ public class VerifyNoCAnswersService {
         return organisation != null
             && prdRepository.findUsersByOrganisation()
             .getOrganisationIdentifier().equals(organisation.getOrganisationID());
+    }
+
+    private Optional<OrganisationPolicy> findPolicy(CaseDetails caseDetails, String caseRoleId) {
+        return caseDetails.findOrganisationPolicyNodes().stream()
+            .map(node -> jacksonUtils.convertValue(node, OrganisationPolicy.class))
+            .filter(policy -> caseRoleId.equalsIgnoreCase(policy.getOrgPolicyCaseAssignedRole()))
+            .findFirst();
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/managecase/TestFixtures.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/TestFixtures.java
@@ -93,7 +93,8 @@ public class TestFixtures {
 
         public static CaseDetails caseDetails(String organizationId, String... orgPolicyRoles) {
             Map<String, JsonNode> jsonNodeMap = Stream.of(orgPolicyRoles)
-                    .collect(Collectors.toMap(role -> "Field_" + role, role -> jsonNode(organizationId, role),
+                    .collect(Collectors.toMap(role -> "Field_" + role,
+                        role -> organisationPolicyJsonNode(organizationId, role),
                         (v1, v2) -> v1, LinkedHashMap::new));
             return defaultCaseDetails().data(jsonNodeMap).build();
         }
@@ -104,7 +105,7 @@ public class TestFixtures {
                 .id(CASE_ID)
                 .jurisdiction(JURISDICTION)
                 .state(null)
-                .data(Maps.newHashMap("OrganisationPolicy1", jsonNode(ORGANIZATION_ID, CASE_ROLE)));
+                .data(Maps.newHashMap("OrganisationPolicy1", organisationPolicyJsonNode(ORGANIZATION_ID, CASE_ROLE)));
         }
 
         public static OrganisationPolicy organisationPolicy(String organizationId, String orgPolicyRole) {
@@ -115,7 +116,7 @@ public class TestFixtures {
                     .build();
         }
 
-        private static JsonNode jsonNode(String organizationId, String orgPolicyRole) {
+        public static JsonNode organisationPolicyJsonNode(String organizationId, String orgPolicyRole) {
             return OBJECT_MAPPER.convertValue(organisationPolicy(organizationId, orgPolicyRole), JsonNode.class);
         }
     }

--- a/src/test/java/uk/gov/hmcts/reform/managecase/service/noc/ChallengeAnswerValidatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/service/noc/ChallengeAnswerValidatorTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.MockitoAnnotations;
-import uk.gov.hmcts.reform.managecase.client.datastore.model.elasticsearch.SearchResultViewItem;
+import uk.gov.hmcts.reform.managecase.client.datastore.CaseDetails;
 import uk.gov.hmcts.reform.managecase.client.definitionstore.model.ChallengeQuestion;
 import uk.gov.hmcts.reform.managecase.client.definitionstore.model.ChallengeQuestionsResult;
 import uk.gov.hmcts.reform.managecase.client.definitionstore.model.FieldType;
@@ -37,7 +37,7 @@ class ChallengeAnswerValidatorTest {
     private ChallengeAnswerValidator challengeAnswerValidator;
 
     private List<SubmittedChallengeAnswer> answers;
-    private SearchResultViewItem caseSearchResult;
+    private CaseDetails caseDetails;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -50,7 +50,7 @@ class ChallengeAnswerValidatorTest {
         answers.add(new SubmittedChallengeAnswer(QUESTION_ID_2, "67890"));
         answers.add(new SubmittedChallengeAnswer(QUESTION_ID_3, "1985-07-25"));
 
-        caseSearchResult = createCase();
+        caseDetails = createCase();
     }
 
     @Test
@@ -71,7 +71,7 @@ class ChallengeAnswerValidatorTest {
         ChallengeQuestionsResult challengeQuestionsResult = new ChallengeQuestionsResult(challengeQuestions);
 
         String result = challengeAnswerValidator
-            .getMatchingCaseRole(challengeQuestionsResult, answers, caseSearchResult);
+            .getMatchingCaseRole(challengeQuestionsResult, answers, caseDetails);
 
         assertThat(result, is("[Claimant]"));
     }
@@ -88,7 +88,7 @@ class ChallengeAnswerValidatorTest {
         ChallengeQuestionsResult challengeQuestionsResult = new ChallengeQuestionsResult(challengeQuestions);
 
         ValidationException exception = assertThrows(ValidationException.class,
-            () -> challengeAnswerValidator.getMatchingCaseRole(challengeQuestionsResult, answers, caseSearchResult));
+            () -> challengeAnswerValidator.getMatchingCaseRole(challengeQuestionsResult, answers, caseDetails));
 
         assertThat(exception.getMessage(),
             is("The number of provided answers must match the number of questions - expected 2 answers, received 3"));
@@ -109,7 +109,7 @@ class ChallengeAnswerValidatorTest {
         ChallengeQuestionsResult challengeQuestionsResult = new ChallengeQuestionsResult(challengeQuestions);
 
         ValidationException exception = assertThrows(ValidationException.class,
-            () -> challengeAnswerValidator.getMatchingCaseRole(challengeQuestionsResult, answers, caseSearchResult));
+            () -> challengeAnswerValidator.getMatchingCaseRole(challengeQuestionsResult, answers, caseDetails));
 
         assertThat(exception.getMessage(), is("No answer has been provided for question ID 'OtherQuestionId1'"));
     }
@@ -130,7 +130,7 @@ class ChallengeAnswerValidatorTest {
         ChallengeQuestionsResult challengeQuestionsResult = new ChallengeQuestionsResult(challengeQuestions);
 
         ValidationException exception = assertThrows(ValidationException.class,
-            () -> challengeAnswerValidator.getMatchingCaseRole(challengeQuestionsResult, answers, caseSearchResult));
+            () -> challengeAnswerValidator.getMatchingCaseRole(challengeQuestionsResult, answers, caseDetails));
 
         assertThat(exception.getMessage(), is("The answers did not uniquely identify a litigant"));
     }
@@ -150,7 +150,7 @@ class ChallengeAnswerValidatorTest {
         ChallengeQuestionsResult challengeQuestionsResult = new ChallengeQuestionsResult(challengeQuestions);
 
         ValidationException exception = assertThrows(ValidationException.class,
-            () -> challengeAnswerValidator.getMatchingCaseRole(challengeQuestionsResult, answers, caseSearchResult));
+            () -> challengeAnswerValidator.getMatchingCaseRole(challengeQuestionsResult, answers, caseDetails));
 
         assertThat(exception.getMessage(), is("The answers did not match those for any litigant"));
     }
@@ -164,7 +164,7 @@ class ChallengeAnswerValidatorTest {
         ChallengeQuestionsResult challengeQuestionsResult = new ChallengeQuestionsResult(challengeQuestions);
 
         String result = challengeAnswerValidator
-            .getMatchingCaseRole(challengeQuestionsResult, answers, caseSearchResult);
+            .getMatchingCaseRole(challengeQuestionsResult, answers, caseDetails);
 
         assertThat(result, is("[Claimant]"));
     }
@@ -178,7 +178,7 @@ class ChallengeAnswerValidatorTest {
         ChallengeQuestionsResult challengeQuestionsResult = new ChallengeQuestionsResult(challengeQuestions);
 
         String result = challengeAnswerValidator
-            .getMatchingCaseRole(challengeQuestionsResult, answers, caseSearchResult);
+            .getMatchingCaseRole(challengeQuestionsResult, answers, caseDetails);
 
         assertThat(result, is("[Claimant]"));
     }
@@ -192,7 +192,7 @@ class ChallengeAnswerValidatorTest {
         ChallengeQuestionsResult challengeQuestionsResult = new ChallengeQuestionsResult(challengeQuestions);
 
         ValidationException exception = assertThrows(ValidationException.class,
-            () -> challengeAnswerValidator.getMatchingCaseRole(challengeQuestionsResult, answers, caseSearchResult));
+            () -> challengeAnswerValidator.getMatchingCaseRole(challengeQuestionsResult, answers, caseDetails));
 
         assertThat(exception.getMessage(), is("The answers did not match those for any litigant"));
     }
@@ -210,10 +210,12 @@ class ChallengeAnswerValidatorTest {
         return FieldType.builder().type(type).build();
     }
 
-    private SearchResultViewItem createCase() throws JsonProcessingException {
-        Map<String, JsonNode> fields = objectMapper.readValue(caseDataString(),
-            new TypeReference<Map<String, JsonNode>>() {});
-        return new SearchResultViewItem("1", fields, fields);
+    private CaseDetails createCase() throws JsonProcessingException {
+        Map<String, JsonNode> data = objectMapper.readValue(caseDataString(), new TypeReference<>() { });
+        return CaseDetails.builder()
+        .id("1")
+        .data(data)
+        .build();
     }
 
     private String caseDataString() {


### PR DESCRIPTION
I would delete unwanted ES model classes and methods from repository layer in the next PR (clean-up).

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/ACA-126

### Change description ###

Notice of change should not use Elastic Search to get the case

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
