### PR TITLE
Reintroduce PMD checks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
   id 'application'
+  id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.9.RELEASE'
   id 'org.springframework.boot' version '2.3.4.RELEASE'
@@ -117,6 +118,16 @@ task functional(type: Test) {
   }
 
   outputs.upToDateWhen { false }
+}
+
+pmd {
+  toolVersion = "6.24.0"
+  maxFailures = 1
+  sourceSets = [sourceSets.main, sourceSets.test, sourceSets.functionalTest, sourceSets.integrationTest]
+  reportsDir = file("$project.buildDir/reports/pmd")
+  // https://github.com/pmd/pmd/issues/876
+  ruleSets = []
+  ruleSetFiles = files("config/pmd/ruleset.xml")
 }
 
 compileJava {

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -129,4 +129,15 @@
 		]]></notes>
     <cve>CVE-2020-8908</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+			temporary suppression
+		]]></notes>
+    <cve>CVE-2020-28052</cve>
+    <cve>CVE-2020-8908</cve>
+    <cve>CVE-2020-29242</cve>
+    <cve>CVE-2020-29243</cve>
+    <cve>CVE-2020-29244</cve>
+    <cve>CVE-2020-29245</cve>
+  </suppress>
 </suppressions>

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<ruleset name="PMD rule set"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+  <description>HMCTS PMD rule set</description>
+
+  <rule ref="category/java/bestpractices.xml">
+    <exclude name="GuardLogStatement"/>
+    <exclude name="JUnitTestContainsTooManyAsserts"/>
+  </rule>
+  <rule ref="category/java/codestyle.xml">
+    <exclude name="AtLeastOneConstructor"/>
+    <exclude name="LocalVariableCouldBeFinal"/>
+    <exclude name="LongVariable"/>
+    <exclude name="MethodArgumentCouldBeFinal"/>
+    <exclude name="OnlyOneReturn"/>
+    <exclude name="TooManyStaticImports"/>
+    <exclude name="DefaultPackage"/>
+    <exclude name="CommentDefaultAccessModifier"/>
+  </rule>
+  <rule ref="category/java/codestyle.xml/ClassNamingConventions">
+    <properties>
+      <!-- same as any other class -->
+      <property name="utilityClassPattern" value="[A-Z][a-zA-Z]+"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/codestyle.xml/MethodNamingConventions">
+    <properties>
+      <property name="junit4TestPattern" value="[a-z][a-zA-Z0-9_]+"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/codestyle.xml/ShortVariable">
+    <properties>
+      <property name="minimum" value="2"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/design.xml">
+    <exclude name="AvoidCatchingGenericException"/>
+    <exclude name="UseUtilityClass"/>
+    <exclude name="LoosePackageCoupling"/>
+    <exclude name="DataClass"/>
+  </rule>
+  <rule ref="category/java/design.xml/ExcessiveImports">
+    <properties>
+      <property name="minimum" value="35"/><!-- should be reduced -->
+    </properties>
+  </rule>
+  <rule ref="category/java/design.xml/LawOfDemeter">
+    <properties>
+      <property name="violationSuppressRegex" value="(.*method chain calls.*|.*object not created locally.*)"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/design.xml/SignatureDeclareThrowsException">
+    <properties>
+      <property name="IgnoreJUnitCompletely" value="true"/>
+    </properties>
+  </rule>
+  <rule ref="category/java/documentation.xml">
+    <exclude name="CommentRequired"/>
+    <exclude name="CommentSize"/>
+    <exclude name="UncommentedEmptyMethodBody"/>
+  </rule>
+  <rule ref="category/java/errorprone.xml">
+    <exclude name="BeanMembersShouldSerialize"/>
+  </rule>
+  <rule ref="category/java/multithreading.xml"/>
+  <rule ref="category/java/performance.xml"/>
+  <rule ref="category/java/security.xml"/>
+
+</ruleset>

--- a/src/integrationTest/java/uk/gov/hmcts/reform/managecase/fixtures/WiremockFixtures.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/managecase/fixtures/WiremockFixtures.java
@@ -52,6 +52,7 @@ public class WiremockFixtures {
     public static final String APPROVER_USER_TOKEN = "Bearer eyJzdWIiOiJjY6ShZ3ciLCJleHAiOlD1OEM0NDUyOTd7co";
     public static final String S2S_TOKEN = "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJjY2RfZ3ciLCJleHAiOjE1ODM0NDUyOTd9"
         + ".WWRzROlKxLQCJw5h0h0dHb9hHfbBhF2Idwv1z4L4FnqSw3VZ38ZRLuDmwr3tj-8oOv6EfLAxV0dJAPtUT203Iw";
+    public static final String CASES = "/cases/";
 
     private static final ObjectMapper OBJECT_MAPPER = new Jackson2ObjectMapperBuilder()
         .modules(new Jdk8Module())
@@ -215,8 +216,9 @@ public class WiremockFixtures {
     }
 
     public static void stubGetCaseViaExternalApi(String caseId, CaseDetails caseDetails) {
-        stubFor(WireMock.get(urlPathEqualTo("/cases/" + caseId))
+        stubFor(WireMock.get(urlPathEqualTo(CASES + caseId))
                     .withHeader(AUTHORIZATION, equalTo(SYS_USER_TOKEN))
+
                     .withHeader(SERVICE_AUTHORIZATION, equalTo(S2S_TOKEN))
                     .willReturn(aResponse()
                                     .withStatus(HTTP_OK)
@@ -238,7 +240,7 @@ public class WiremockFixtures {
     public static void stubGetExternalStartEventTrigger(String caseId,
                                                                   String eventId,
                                                                   StartEventResource startEventResource) {
-        stubFor(WireMock.get(urlPathEqualTo("/cases/" + caseId + "/event-triggers/" + eventId))
+        stubFor(WireMock.get(urlPathEqualTo(CASES + caseId + "/event-triggers/" + eventId))
             .withHeader(AUTHORIZATION, equalTo(SYS_USER_TOKEN))
             .withHeader(SERVICE_AUTHORIZATION, equalTo(S2S_TOKEN))
             .willReturn(aResponse()
@@ -250,7 +252,7 @@ public class WiremockFixtures {
     public static void stubGetExternalStartEventTriggerAsApprover(String caseId,
                                                           String eventId,
                                                           StartEventResource startEventResource) {
-        stubFor(WireMock.get(urlPathEqualTo("/cases/" + caseId + "/event-triggers/" + eventId))
+        stubFor(WireMock.get(urlPathEqualTo(CASES + caseId + "/event-triggers/" + eventId))
             .withHeader(AUTHORIZATION, equalTo(APPROVER_USER_TOKEN))
             .withHeader(SERVICE_AUTHORIZATION, equalTo(S2S_TOKEN))
             .willReturn(aResponse()
@@ -262,7 +264,7 @@ public class WiremockFixtures {
     public static void stubSubmitEventForCase(String caseId,
                                               CaseEventCreationPayload caseEventCreationPayload,
                                               CaseDetails caseDetails) throws JsonProcessingException {
-        stubFor(WireMock.post(urlPathEqualTo("/cases/" + caseId + "/events"))
+        stubFor(WireMock.post(urlPathEqualTo(CASES + caseId + "/events"))
                     .withHeader(AUTHORIZATION, equalTo(APPROVER_USER_TOKEN))
                     .withHeader(SERVICE_AUTHORIZATION, equalTo(S2S_TOKEN))
                     .withRequestBody(equalToJson(
@@ -276,7 +278,7 @@ public class WiremockFixtures {
 
     public static void stubSubmitEventForCase(String caseID,
                                               CaseDetails caseDetails) {
-        stubFor(WireMock.post(urlEqualTo("/cases/" + caseID + "/events"))
+        stubFor(WireMock.post(urlEqualTo(CASES + caseID + "/events"))
                     .withHeader(AUTHORIZATION, equalTo(SYS_USER_TOKEN))
                     .withHeader(SERVICE_AUTHORIZATION, equalTo(S2S_TOKEN))
                     .willReturn(aResponse()
@@ -285,7 +287,7 @@ public class WiremockFixtures {
     }
 
     public static void stubGetCaseDetailsByCaseIdViaExternalApi(String caseId, CaseDetails caseDetails) {
-        stubFor(WireMock.get(urlEqualTo("/cases/" + caseId))
+        stubFor(WireMock.get(urlEqualTo(CASES + caseId))
                     .withHeader(AUTHORIZATION, equalTo(SYS_USER_TOKEN))
                     .withHeader(SERVICE_AUTHORIZATION, equalTo(S2S_TOKEN))
                     .willReturn(aResponse()

--- a/src/main/java/uk/gov/hmcts/reform/managecase/api/controller/NoticeOfChangeController.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/api/controller/NoticeOfChangeController.java
@@ -60,7 +60,7 @@ import static uk.gov.hmcts.reform.managecase.domain.ApprovalStatus.APPROVED;
 @RestController
 @Validated
 @RequestMapping(path = "/noc")
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.ExcessiveImports", "PMD.UnnecessaryFullyQualifiedName"})
 public class NoticeOfChangeController {
 
     @SuppressWarnings({"squid:S1075"})
@@ -488,6 +488,7 @@ public class NoticeOfChangeController {
             CHECK_NOC_APPROVAL_DECISION_APPLIED_MESSAGE);
     }
 
+    @SuppressWarnings("PMD.LinguisticNaming")
     @PostMapping(path = SET_ORGANISATION_TO_REMOVE_PATH, produces = APPLICATION_JSON_VALUE)
     @ApiOperation(value = "Set Organisation To Remove", notes = "Set Organisation To Remove")
     @ApiResponses({

--- a/src/main/java/uk/gov/hmcts/reform/managecase/domain/ChangeOrganisationRequest.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/domain/ChangeOrganisationRequest.java
@@ -40,6 +40,7 @@ public class ChangeOrganisationRequest {
     @JsonProperty("ApprovalStatus")
     private String approvalStatus;
 
+    @SuppressWarnings("PMD.UselessParentheses")
     public void validateChangeOrganisationRequest() {
         if (this.getCaseRoleId() == null
             || StringUtils.isBlank(this.getApprovalStatus())

--- a/src/main/java/uk/gov/hmcts/reform/managecase/service/noc/NoticeOfChangeApprovalService.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/service/noc/NoticeOfChangeApprovalService.java
@@ -19,7 +19,12 @@ import static uk.gov.hmcts.reform.managecase.api.errorhandling.ValidationError.C
 import static uk.gov.hmcts.reform.managecase.api.errorhandling.ValidationError.EVENT_TOKEN_NOT_PRESENT;
 
 @Service
-@SuppressWarnings({"PMD.DataflowAnomalyAnalysis", "PMD.GodClass", "PMD.ExcessiveImports", "PMD.TooManyMethods"})
+@SuppressWarnings({"PMD.DataflowAnomalyAnalysis",
+    "PMD.GodClass",
+    "PMD.ExcessiveImports",
+    "PMD.TooManyMethods",
+    "PMD.LawOfDemeter",
+    "PMD.PreserveStackTrace"})
 public class NoticeOfChangeApprovalService {
 
     private static final int EXPECTED_NUMBER_OF_EVENTS = 1;

--- a/src/main/java/uk/gov/hmcts/reform/managecase/service/noc/NoticeOfChangeQuestions.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/service/noc/NoticeOfChangeQuestions.java
@@ -19,7 +19,6 @@ import uk.gov.hmcts.reform.managecase.domain.NoCRequestDetails;
 import uk.gov.hmcts.reform.managecase.domain.OrganisationPolicy;
 import uk.gov.hmcts.reform.managecase.repository.DataStoreRepository;
 import uk.gov.hmcts.reform.managecase.repository.DefinitionStoreRepository;
-import uk.gov.hmcts.reform.managecase.repository.PrdRepository;
 import uk.gov.hmcts.reform.managecase.security.SecurityUtils;
 import uk.gov.hmcts.reform.managecase.util.JacksonUtils;
 
@@ -36,6 +35,10 @@ import static uk.gov.hmcts.reform.managecase.api.errorhandling.ValidationError.N
 import static uk.gov.hmcts.reform.managecase.api.errorhandling.ValidationError.NOC_REQUEST_ONGOING;
 import static uk.gov.hmcts.reform.managecase.api.errorhandling.ValidationError.NO_ORG_POLICY_WITH_ROLE;
 
+@SuppressWarnings({"PMD.DataflowAnomalyAnalysis",
+    "PMD.PreserveStackTrace",
+    "PMD.LawOfDemeter",
+    "PMD.AvoidLiteralsInIfCondition"})
 @Service
 public class NoticeOfChangeQuestions {
 
@@ -45,19 +48,16 @@ public class NoticeOfChangeQuestions {
 
     private final DataStoreRepository dataStoreRepository;
     private final DefinitionStoreRepository definitionStoreRepository;
-    private final PrdRepository prdRepository;
     private final JacksonUtils jacksonUtils;
     private final SecurityUtils securityUtils;
 
     @Autowired
     public NoticeOfChangeQuestions(@Qualifier("defaultDataStoreRepository") DataStoreRepository dataStoreRepository,
                                    DefinitionStoreRepository definitionStoreRepository,
-                                   PrdRepository prdRepository,
                                    JacksonUtils jacksonUtils,
                                    SecurityUtils securityUtils) {
         this.dataStoreRepository = dataStoreRepository;
         this.definitionStoreRepository = definitionStoreRepository;
-        this.prdRepository = prdRepository;
         this.jacksonUtils = jacksonUtils;
         this.securityUtils = securityUtils;
     }

--- a/src/main/java/uk/gov/hmcts/reform/managecase/service/noc/PrepareNoCService.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/service/noc/PrepareNoCService.java
@@ -40,7 +40,7 @@ import static uk.gov.hmcts.reform.managecase.client.datastore.CaseDetails.CASE_R
 import static uk.gov.hmcts.reform.managecase.client.datastore.CaseDetails.ORGANISATION_REQUEST_TIMESTAMP;
 
 @Service
-@SuppressWarnings({"PMD.UseLocaleWithCaseConversions"})
+@SuppressWarnings({"PMD.UseLocaleWithCaseConversions", "PMD.ExcessiveImports"})
 public class PrepareNoCService {
 
     private final PrdRepository prdRepository;

--- a/src/main/java/uk/gov/hmcts/reform/managecase/service/noc/RequestNoticeOfChangeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/service/noc/RequestNoticeOfChangeService.java
@@ -34,6 +34,10 @@ import static uk.gov.hmcts.reform.managecase.api.errorhandling.ValidationError.I
 import static uk.gov.hmcts.reform.managecase.domain.ApprovalStatus.APPROVED;
 import static uk.gov.hmcts.reform.managecase.domain.ApprovalStatus.PENDING;
 
+@SuppressWarnings({"PMD.DataflowAnomalyAnalysis",
+    "PMD.AvoidLiteralsInIfCondition",
+    "PMD.UseLocaleWithCaseConversions",
+    "PMD.UseConcurrentHashMap"})
 @Service
 public class RequestNoticeOfChangeService {
 
@@ -50,8 +54,7 @@ public class RequestNoticeOfChangeService {
     private final SecurityUtils securityUtils;
 
     @Autowired
-    public RequestNoticeOfChangeService(NoticeOfChangeQuestions noticeOfChangeQuestions,
-                                        @Qualifier("defaultDataStoreRepository")
+    public RequestNoticeOfChangeService(@Qualifier("defaultDataStoreRepository")
                                             DataStoreRepository dataStoreRepository,
                                         DefinitionStoreRepository definitionStoreRepository,
                                         PrdRepository prdRepository,
@@ -99,6 +102,7 @@ public class RequestNoticeOfChangeService {
             .build();
     }
 
+    @SuppressWarnings({"PMD.LinguisticNaming"})
     public AboutToSubmitCallbackResponse setOrganisationToRemove(CaseDetails caseDetails,
                                                                  ChangeOrganisationRequest changeOrganisationRequest,
                                                                  String changeOrganisationKey) {

--- a/src/main/java/uk/gov/hmcts/reform/managecase/util/JacksonUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/util/JacksonUtils.java
@@ -8,14 +8,12 @@ import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.managecase.domain.DynamicList;
 import uk.gov.hmcts.reform.managecase.domain.DynamicListElement;
 
-import java.util.List;
-
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
-import java.util.Arrays;
-import java.util.List;
-
+@SuppressWarnings("PMD.DataflowAnomalyAnalysis")
 @Component
 public class JacksonUtils {
 
@@ -34,7 +32,7 @@ public class JacksonUtils {
      * Nullify all fields within an object node - all fields are set to null nodes.
      * NOTE: Arrays are not supported
      * @param node object node to be nullified
-     * @param ignoredNestedFields names of fields that will be set to NullNode, even if they are nested fields
+     * @param ignoreNestedFields names of fields that will be set to NullNode, even if they are nested fields
      */
     public void nullifyObjectNode(ObjectNode node, String... ignoreNestedFields) {
         List<String> ignoredNestedFieldsList = Arrays.asList(ignoreNestedFields);
@@ -46,15 +44,15 @@ public class JacksonUtils {
             }
         });
     }
-    
+
     public static void merge(Map<String, JsonNode> mergeFrom, Map<String, JsonNode> mergeInto) {
 
         for (String key : mergeFrom.keySet()) {
             JsonNode value = mergeFrom.get(key);
-            if (!mergeInto.containsKey(key)) {
-                mergeInto.put(key, value);
-            } else {
+            if (mergeInto.containsKey(key)) {
                 mergeInto.put(key, merge(mergeInto.get(key), value));
+            } else {
+                mergeInto.put(key, value);
             }
         }
     }

--- a/src/test/java/uk/gov/hmcts/reform/managecase/api/controller/NoticeOfChangeControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/api/controller/NoticeOfChangeControllerTest.java
@@ -53,7 +53,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static java.util.Collections.emptyList;
@@ -97,7 +96,11 @@ import static uk.gov.hmcts.reform.managecase.api.errorhandling.ValidationError.C
 import static uk.gov.hmcts.reform.managecase.api.errorhandling.ValidationError.CHALLENGE_QUESTION_ANSWERS_EMPTY;
 import static uk.gov.hmcts.reform.managecase.api.errorhandling.ValidationError.CHANGE_ORG_REQUEST_FIELD_MISSING_OR_INVALID;
 
-@SuppressWarnings({"PMD.AvoidDuplicateLiterals", "PMD.JUnitTestsShouldIncludeAssert", "PMD.ExcessiveImports"})
+@SuppressWarnings({"PMD.AvoidDuplicateLiterals",
+    "PMD.JUnitTestsShouldIncludeAssert",
+    "PMD.ExcessiveImports",
+    "PMD.LawOfDemeter",
+    "PMD.UseConcurrentHashMap"})
 public class NoticeOfChangeControllerTest {
 
     private static final String CASE_ID = "1588234985453946";

--- a/src/test/java/uk/gov/hmcts/reform/managecase/client/datastore/CaseDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/client/datastore/CaseDetailsTest.java
@@ -20,12 +20,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.gov.hmcts.reform.managecase.client.datastore.CaseDetails.ORGANISATION_TO_REMOVE;
 
+@SuppressWarnings({"PMD.JUnitAssertionsShouldIncludeMessage", "PMD.LawOfDemeter"})
 class CaseDetailsTest {
     private static final String COR_FIELD_NAME = "ChangeOrganisationRequestField2";
 
     private static final JsonNodeFactory JSON_NODE_FACTORY = new JsonNodeFactory(false);
 
-    private ObjectMapper objectMapper = new ObjectMapper()
+    private final ObjectMapper objectMapper = new ObjectMapper()
         .registerModule(new ParameterNamesModule(JsonCreator.Mode.PROPERTIES));
 
     @Test
@@ -90,6 +91,7 @@ class CaseDetailsTest {
         assertEquals("CMC", caseDetails.getJurisdiction());
     }
 
+    @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
     @Test
     void shouldSerialiseToCaseIdAlways() throws Exception {
 

--- a/src/test/java/uk/gov/hmcts/reform/managecase/repository/DataStoreRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/repository/DataStoreRepositoryTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import uk.gov.hmcts.reform.managecase.TestFixtures.CaseUpdateViewEventFixture;
 import uk.gov.hmcts.reform.managecase.api.errorhandling.CaseCouldNotBeFetchedException;
 import uk.gov.hmcts.reform.managecase.client.datastore.CaseDetails;
 import uk.gov.hmcts.reform.managecase.client.datastore.CaseEventCreationPayload;
@@ -58,7 +57,7 @@ import static uk.gov.hmcts.reform.managecase.repository.DefaultDataStoreReposito
 import static uk.gov.hmcts.reform.managecase.repository.DefaultDataStoreRepository.NOT_ENOUGH_DATA_TO_SUBMIT_START_EVENT;
 import static uk.gov.hmcts.reform.managecase.service.CaseAssignmentService.CASE_COULD_NOT_BE_FETCHED;
 
-@SuppressWarnings({"PMD.ExcessiveImports", "PMD.TooManyMethods"})
+@SuppressWarnings({"PMD.ExcessiveImports", "PMD.TooManyMethods", "PMD.UseConcurrentHashMap"})
 class DataStoreRepositoryTest {
 
     private static final String CASE_TYPE_ID = "TEST_CASE_TYPE";
@@ -327,7 +326,7 @@ class DataStoreRepositoryTest {
     void shouldReturnCaseDetailsWhenSubmittingEventSucceeds() throws JsonProcessingException {
         // ARRANGE
         CaseUpdateViewEvent caseUpdateViewEvent = CaseUpdateViewEvent.builder()
-            .wizardPages(CaseUpdateViewEventFixture.getWizardPages())
+            .wizardPages(getWizardPages())
             .eventToken(EVENT_TOKEN)
             .caseFields(getCaseViewFields())
             .build();
@@ -428,7 +427,7 @@ class DataStoreRepositoryTest {
 
         // ARRANGE
         CaseUpdateViewEvent caseUpdateViewEvent = CaseUpdateViewEvent.builder()
-            .wizardPages(CaseUpdateViewEventFixture.getWizardPages())
+            .wizardPages(getWizardPages())
             .eventToken(EVENT_TOKEN)
             .caseFields(getCaseViewFields())
             .build();

--- a/src/test/java/uk/gov/hmcts/reform/managecase/service/noc/NoticeOfChangeQuestionsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/service/noc/NoticeOfChangeQuestionsTest.java
@@ -63,10 +63,8 @@ class NoticeOfChangeQuestionsTest {
     private static final String CASE_TYPE_ID = "TEST_CASE_TYPE";
     private static final String CASE_ID = "1567934206391385";
     private static final String JURISDICTION = "Jurisdiction";
-    private static final String CASE_TYPE = "CaseTypeA";
     private static final String QUESTION_TEXT = "QuestionText1";
     private static final String FIELD_ID = "Number";
-    private static final String CHANGE_ORG = "changeOrg";
     private static final String CHALLENGE_QUESTION = "NoC";
     private static final String ANSWER_FIELD = "${applicant.individual.fullname}|${applicant.company.name}|"
         + "${applicant.soletrader.name}:Applicant,${respondent.individual.fullname}|${respondent.company.name}"

--- a/src/test/java/uk/gov/hmcts/reform/managecase/service/noc/VerifyNoCAnswersServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/service/noc/VerifyNoCAnswersServiceTest.java
@@ -37,6 +37,8 @@ import static org.mockito.Mockito.when;
     "PMD.UseConcurrentHashMap"})
 class VerifyNoCAnswersServiceTest {
 
+    private static final String DEFENDANT = "[Defendant]";
+
     @InjectMocks
     private VerifyNoCAnswersService verifyNoCAnswersService;
 
@@ -75,7 +77,7 @@ class VerifyNoCAnswersServiceTest {
 
         given(jacksonUtils.convertValue(any(JsonNode.class), eq(OrganisationPolicy.class)))
             .willReturn(OrganisationPolicy.builder()
-                .orgPolicyCaseAssignedRole("[Defendant]")
+                .orgPolicyCaseAssignedRole(DEFENDANT)
                 .orgPolicyReference("DefendantPolicy")
                 .organisation(new Organisation("QUK822NA", "SomeOrg"))
                 .build()
@@ -85,14 +87,14 @@ class VerifyNoCAnswersServiceTest {
     @Test
     void shouldVerifyNoCAnswersSuccessfully() {
         mockPrdResponse("ORGID1");
-        when(challengeAnswerValidator.getMatchingCaseRole(any(), any(), any())).thenReturn("[Defendant]");
+        when(challengeAnswerValidator.getMatchingCaseRole(any(), any(), any())).thenReturn(DEFENDANT);
 
         VerifyNoCAnswersRequest request = new VerifyNoCAnswersRequest("1", emptyList());
 
         NoCRequestDetails result = verifyNoCAnswersService.verifyNoCAnswers(request);
 
         assertAll(
-            () -> assertThat(result.getOrganisationPolicy().getOrgPolicyCaseAssignedRole(), is("[Defendant]")),
+            () -> assertThat(result.getOrganisationPolicy().getOrgPolicyCaseAssignedRole(), is(DEFENDANT)),
             () -> assertThat(result.getOrganisationPolicy().getOrgPolicyReference(), is("DefendantPolicy")),
             () -> assertThat(result.getOrganisationPolicy().getOrganisation().getOrganisationID(), is("QUK822NA")),
             () -> assertThat(result.getOrganisationPolicy().getOrganisation().getOrganisationName(), is("SomeOrg")),
@@ -122,7 +124,7 @@ class VerifyNoCAnswersServiceTest {
     void shouldErrorWhenRequestingUserIsInSameOrganisationAsIdentifiedOrgPolicy() {
         mockPrdResponse("QUK822NA");
         when(challengeAnswerValidator.getMatchingCaseRole(any(), any(), any()))
-            .thenReturn("[Defendant]");
+            .thenReturn(DEFENDANT);
 
         VerifyNoCAnswersRequest request = new VerifyNoCAnswersRequest("1", emptyList());
 
@@ -161,7 +163,7 @@ class VerifyNoCAnswersServiceTest {
             + "            \"OrganisationName\": \"SomeOrg\"\n"
             + "        },\n"
             + "        \"OrgPolicyReference\": \"DefendantPolicy\",\n"
-            + "        \"OrgPolicyCaseAssignedRole\": \"[Defendant]\"\n"
+            + "        \"OrgPolicyCaseAssignedRole\": \"" + DEFENDANT + "\"\n"
             + "    },\n"
             + "    \"OrganisationPolicyField2\": {\n"
             + "        \"Organisation\": {\n"

--- a/src/test/java/uk/gov/hmcts/reform/managecase/util/JacksonUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/util/JacksonUtilsTest.java
@@ -17,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+@SuppressWarnings({"PMD.DataflowAnomalyAnalysis", "PMD.JUnitAssertionsShouldIncludeMessage"})
 class JacksonUtilsTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
### Change description ###

PMD checks had been mistakenly removed, in the belief that they would be inherited from the HMCTS Gradle plugin, but that is checkstyle only.  This reintroduces PMD and fixes reported errors

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
