### PR TITLE
ACA-134 - Adjust ApplyNoCDecision API JSON output

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/managecase/api/controller/NoticeOfChangeControllerIT.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/managecase/api/controller/NoticeOfChangeControllerIT.java
@@ -374,11 +374,11 @@ public class NoticeOfChangeControllerIT {
                 .andExpect(jsonPath("$.data.OrganisationPolicyField1.OrgPolicyCaseAssignedRole", is(ORG_POLICY_1_ROLE)))
                 .andExpect(jsonPath("$.data.OrganisationPolicyField2.Organisation.OrganisationID").isEmpty())
                 .andExpect(jsonPath("$.data.OrganisationPolicyField2.Organisation.OrganisationName").isEmpty())
-                .andExpect(jsonPath("$.data.OrganisationPolicyField2.PreviousOrganisations[0].OrganisationName",
+                .andExpect(jsonPath("$.data.OrganisationPolicyField2.PreviousOrganisations[0].value.OrganisationName",
                                     is(ORG_2_NAME)))
-                .andExpect(jsonPath("$.data.OrganisationPolicyField2.PreviousOrganisations[0].FromTimestamp")
+                .andExpect(jsonPath("$.data.OrganisationPolicyField2.PreviousOrganisations[0].value.FromTimestamp")
                                .isNotEmpty())
-                .andExpect(jsonPath("$.data.OrganisationPolicyField2.PreviousOrganisations[0].ToTimestamp")
+                .andExpect(jsonPath("$.data.OrganisationPolicyField2.PreviousOrganisations[0].value.ToTimestamp")
                                .isNotEmpty())
                 .andExpect(jsonPath("$.data.OrganisationPolicyField2.OrgPolicyReference", is(ORG_POLICY_2_REF)))
                 .andExpect(jsonPath("$.data.OrganisationPolicyField2.OrgPolicyCaseAssignedRole", is(ORG_POLICY_2_ROLE)))

--- a/src/main/java/uk/gov/hmcts/reform/managecase/client/datastore/model/WizardPageComplexFieldOverride.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/client/datastore/model/WizardPageComplexFieldOverride.java
@@ -16,6 +16,9 @@ public class WizardPageComplexFieldOverride implements Serializable {
     @JsonProperty("display_context")
     private String displayContext;
 
+    @JsonProperty("retain_hidden_value")
+    private Boolean retainHiddenValue;
+
     @JsonProperty("label")
     private String label;
 

--- a/src/main/java/uk/gov/hmcts/reform/managecase/domain/AddressUK.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/domain/AddressUK.java
@@ -10,20 +10,20 @@ import lombok.NoArgsConstructor;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class OrganisationAddress {
+public class AddressUK {
 
-    @JsonProperty("addressLine1")
+    @JsonProperty("AddressLine1")
     private String addressLine1;
-    @JsonProperty("addressLine2")
+    @JsonProperty("AddressLine2")
     private String addressLine2;
-    @JsonProperty("addressLine3")
+    @JsonProperty("AddressLine3")
     private String addressLine3;
-    @JsonProperty("townCity")
-    private String townCity;
-    @JsonProperty("county")
+    @JsonProperty("PostTown")
+    private String postTown;
+    @JsonProperty("County")
     private String county;
-    @JsonProperty("country")
+    @JsonProperty("Country")
     private String country;
-    @JsonProperty("postCode")
+    @JsonProperty("PostCode")
     private String postCode;
 }

--- a/src/main/java/uk/gov/hmcts/reform/managecase/domain/OrganisationPolicy.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/domain/OrganisationPolicy.java
@@ -20,6 +20,6 @@ public class OrganisationPolicy {
     @JsonProperty("OrgPolicyCaseAssignedRole")
     private String orgPolicyCaseAssignedRole;
     @JsonProperty("PreviousOrganisations")
-    private List<PreviousOrganisation> previousOrganisations;
+    private List<PreviousOrganisationCollectionItem> previousOrganisations;
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/managecase/domain/PreviousOrganisation.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/domain/PreviousOrganisation.java
@@ -2,7 +2,6 @@ package uk.gov.hmcts.reform.managecase.domain;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -21,5 +20,5 @@ public class PreviousOrganisation {
     @JsonProperty("ToTimestamp")
     private LocalDateTime toTimestamp;
     @JsonProperty("OrganisationAddress")
-    private List<OrganisationAddress> organisationAddresses;
+    private AddressUK organisationAddress;
 }

--- a/src/main/java/uk/gov/hmcts/reform/managecase/domain/PreviousOrganisationCollectionItem.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/domain/PreviousOrganisationCollectionItem.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.managecase.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class PreviousOrganisationCollectionItem {
+    @JsonProperty("id")
+    private String id;
+
+    @JsonProperty("value")
+    private PreviousOrganisation value;
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -57,7 +57,7 @@ idam:
     totp_secret: ${MANAGE_CASE_S2S_KEY:AAAAAAAAAAAAAAAA}
     url: ${S2S_URL:http://localhost:4502}
   s2s-authorised:
-    services: ${MANAGE_CASE_S2S_AUTHORISED_SERVICES:xui_webapp}
+    services: ${MANAGE_CASE_S2S_AUTHORISED_SERVICES:xui_webapp,ccd_data,finrem_case_orchestration}
 oidc:
   issuer: ${OIDC_ISSUER:http://fr-am:8080/openam/oauth2/hmcts}
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [ACA-134](https://tools.hmcts.net/jira/browse/ACA-1334) _"Adjust PreviousOrganisation JSON format used by ApplyNoCDecision API (Phase 2A)"_
  see also  [ACA-106](https://tools.hmcts.net/jira/browse/ACA-106) _"Update ApplyNoCDecision API (Phase 2A)"_

### Change description ###

Adjust `PreviousOrganisation` JSON format returned by ApplyNoCDecision API after recent changes under [ACA-106](https://tools.hmcts.net/jira/browse/ACA-106), see #171.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
