### PR TITLE
RDM-10705 - Point to pre-release befta-fw version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -286,7 +286,7 @@ dependencies {
   integrationTestImplementation sourceSets.main.runtimeClasspath
   integrationTestImplementation sourceSets.test.runtimeClasspath
 
-  testImplementation group: 'uk.gov.hmcts', name: 'befta-fw', version: '6.5.3-RDM-10705'
+  testImplementation group: 'uk.gov.hmcts', name: 'befta-fw', version: '6.5.3'
 
   functionalTestImplementation sourceSets.main.runtimeClasspath
   functionalTestImplementation sourceSets.test.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -286,7 +286,7 @@ dependencies {
   integrationTestImplementation sourceSets.main.runtimeClasspath
   integrationTestImplementation sourceSets.test.runtimeClasspath
 
-  testImplementation group: 'uk.gov.hmcts', name: 'befta-fw', version: '6.2.0'
+  testImplementation group: 'uk.gov.hmcts', name: 'befta-fw', version: '6.5.3-RDM-10705'
 
   functionalTestImplementation sourceSets.main.runtimeClasspath
   functionalTestImplementation sourceSets.test.runtimeClasspath

--- a/src/main/java/uk/gov/hmcts/reform/managecase/client/datastore/model/WizardPageComplexFieldOverride.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/client/datastore/model/WizardPageComplexFieldOverride.java
@@ -1,11 +1,13 @@
 package uk.gov.hmcts.reform.managecase.client.datastore.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.io.Serializable;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class WizardPageComplexFieldOverride implements Serializable {
 
     private static final long serialVersionUID = -7035807257796312777L;

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -57,7 +57,7 @@ idam:
     totp_secret: ${MANAGE_CASE_S2S_KEY:AAAAAAAAAAAAAAAA}
     url: ${S2S_URL:http://localhost:4502}
   s2s-authorised:
-    services: ${MANAGE_CASE_S2S_AUTHORISED_SERVICES:xui_webapp}
+    services: ${MANAGE_CASE_S2S_AUTHORISED_SERVICES:xui_webapp,ccd_data,finrem_case_orchestration}
 oidc:
   issuer: ${OIDC_ISSUER:http://fr-am:8080/openam/oauth2/hmcts}
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [RDM-10705](https://tools.hmcts.net/jira/browse/RDM-10705) _"Data-store FTA 403 failures when running against a local ccd-docker environment"_

### Change description ###

Point to yet to be released pre-release version of befta-fw, see hmcts/befta-fw#133.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
