### PR TITLE
RDM-11407 - fixing COR field merge

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/managecase/repository/DefaultDataStoreRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/repository/DefaultDataStoreRepository.java
@@ -22,6 +22,7 @@ import uk.gov.hmcts.reform.managecase.domain.ChangeOrganisationRequest;
 import uk.gov.hmcts.reform.managecase.security.SecurityUtils;
 import uk.gov.hmcts.reform.managecase.util.JacksonUtils;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -212,9 +213,11 @@ public class DefaultDataStoreRepository implements DataStoreRepository {
     private Map<String, JsonNode> getCaseDataContentData(String caseFieldId,
                                                          ChangeOrganisationRequest changeOrganisationRequest,
                                                          Map<String, JsonNode> caseDetailsData) {
+        Map<String, JsonNode> data = new HashMap<>();
 
-        caseDetailsData.put(caseFieldId, jacksonUtils.convertValue(changeOrganisationRequest, JsonNode.class));
+        data.put(caseFieldId, jacksonUtils.convertValue(changeOrganisationRequest, JsonNode.class));
 
+        jacksonUtils.merge(data, caseDetailsData);
         return caseDetailsData;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/managecase/repository/DefaultDataStoreRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/repository/DefaultDataStoreRepository.java
@@ -22,7 +22,6 @@ import uk.gov.hmcts.reform.managecase.domain.ChangeOrganisationRequest;
 import uk.gov.hmcts.reform.managecase.security.SecurityUtils;
 import uk.gov.hmcts.reform.managecase.util.JacksonUtils;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -213,11 +212,9 @@ public class DefaultDataStoreRepository implements DataStoreRepository {
     private Map<String, JsonNode> getCaseDataContentData(String caseFieldId,
                                                          ChangeOrganisationRequest changeOrganisationRequest,
                                                          Map<String, JsonNode> caseDetailsData) {
-        Map<String, JsonNode> data = new HashMap<>();
 
-        data.put(caseFieldId, jacksonUtils.convertValue(changeOrganisationRequest, JsonNode.class));
+        caseDetailsData.put(caseFieldId, jacksonUtils.convertValue(changeOrganisationRequest, JsonNode.class));
 
-        JacksonUtils.merge(caseDetailsData, data);
-        return data;
+        return caseDetailsData;
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/managecase/util/JacksonUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/util/JacksonUtils.java
@@ -46,8 +46,8 @@ public class JacksonUtils {
             }
         });
     }
-    
-    public static void merge(Map<String, JsonNode> mergeFrom, Map<String, JsonNode> mergeInto) {
+
+    public void merge(Map<String, JsonNode> mergeFrom, Map<String, JsonNode> mergeInto) {
 
         for (String key : mergeFrom.keySet()) {
             JsonNode value = mergeFrom.get(key);

--- a/src/main/java/uk/gov/hmcts/reform/managecase/util/JacksonUtils.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/util/JacksonUtils.java
@@ -77,7 +77,7 @@ public class JacksonUtils {
             } else if (valueToBeUpdated != null && valueToBeUpdated.isObject()) {
                 merge(valueToBeUpdated, updatedValue);
             } else {
-                if (mainNode instanceof ObjectNode) {
+                if (mainNode instanceof ObjectNode && !updatedValue.isNull()) {
                     ((ObjectNode) mainNode).replace(updatedFieldName, updatedValue);
                 }
             }

--- a/src/test/java/uk/gov/hmcts/reform/managecase/repository/DataStoreRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/repository/DataStoreRepositoryTest.java
@@ -330,6 +330,7 @@ class DataStoreRepositoryTest {
 
 
         given(jacksonUtils.convertValue(any(), any())).willReturn(mapper.readTree(EXPECTED_NOC_REQUEST_DATA));
+        doNothing().when(jacksonUtils).merge(any(), eq(data));
 
         ChangeOrganisationRequest changeOrganisationRequest = ChangeOrganisationRequest.builder()
             .organisationToAdd(Organisation.builder().organisationID("orgNameToAdd").build())

--- a/src/test/java/uk/gov/hmcts/reform/managecase/repository/DataStoreRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/repository/DataStoreRepositoryTest.java
@@ -3,10 +3,8 @@ package uk.gov.hmcts.reform.managecase.repository;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import feign.FeignException;
+import feign.Request;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,6 +12,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import uk.gov.hmcts.reform.managecase.TestFixtures.CaseUpdateViewEventFixture;
+import uk.gov.hmcts.reform.managecase.api.errorhandling.CaseCouldNotBeFetchedException;
 import uk.gov.hmcts.reform.managecase.client.datastore.CaseDetails;
 import uk.gov.hmcts.reform.managecase.client.datastore.CaseEventCreationPayload;
 import uk.gov.hmcts.reform.managecase.client.datastore.CaseUserRole;
@@ -32,7 +31,14 @@ import uk.gov.hmcts.reform.managecase.domain.Organisation;
 import uk.gov.hmcts.reform.managecase.security.SecurityUtils;
 import uk.gov.hmcts.reform.managecase.util.JacksonUtils;
 
+import java.nio.charset.Charset;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -49,6 +55,7 @@ import static uk.gov.hmcts.reform.managecase.domain.ApprovalStatus.PENDING;
 import static uk.gov.hmcts.reform.managecase.repository.DefaultDataStoreRepository.CHANGE_ORGANISATION_REQUEST_MISSING_CASE_FIELD_ID;
 import static uk.gov.hmcts.reform.managecase.repository.DefaultDataStoreRepository.NOC_REQUEST_DESCRIPTION;
 import static uk.gov.hmcts.reform.managecase.repository.DefaultDataStoreRepository.NOT_ENOUGH_DATA_TO_SUBMIT_START_EVENT;
+import static uk.gov.hmcts.reform.managecase.service.CaseAssignmentService.CASE_COULD_NOT_BE_FETCHED;
 
 
 @SuppressWarnings({"PMD.ExcessiveImports", "PMD.TooManyMethods"})
@@ -122,6 +129,24 @@ class DataStoreRepositoryTest {
         // ASSERT
         assertThat(result).isNull();
         verify(dataStoreApi).getCaseDetailsByCaseIdViaExternalApi(eq(CASE_ID));
+    }
+
+    @Test
+    @DisplayName("find case by id using external facing API throws CaseCouldNotBeFetchedException")
+    void shouldThrowCaseCouldNotBeFetchedExceptionForFindCaseByIdUsingExternalApi() {
+        // ARRANGE
+        given(dataStoreApi.getCaseDetailsByCaseIdViaExternalApi(CASE_ID))
+            .willThrow(new FeignException.NotFound("404",
+                                                   Request.create(Request.HttpMethod.GET, "someUrl", Map.of(),
+                                                                  null, Charset.defaultCharset(),
+                                                                  null
+                                                   ), null
+            ));
+
+        // ACT & ASSERT
+        assertThatThrownBy(() -> repository.findCaseByCaseIdExternalApi(CASE_ID))
+            .isInstanceOf(CaseCouldNotBeFetchedException.class)
+            .hasMessageContaining(CASE_COULD_NOT_BE_FETCHED);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/managecase/util/JacksonUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/util/JacksonUtilsTest.java
@@ -8,19 +8,69 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 import uk.gov.hmcts.reform.managecase.domain.DynamicList;
 import uk.gov.hmcts.reform.managecase.domain.DynamicListElement;
 
 import java.util.Arrays;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Maps.newHashMap;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.skyscreamer.jsonassert.JSONCompareMode.LENIENT;
 
 class JacksonUtilsTest {
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    public static final String COR_STRING = "{\n"
+        + "    \"CaseRoleId\": {\n"
+        + "      \"value\": {\n"
+        + "        \"code\": \"[LEGALREPRESENTATIVE]\",\n"
+        + "        \"label\": \"Legal Representative\"\n"
+        + "      },\n"
+        + "      \"list_items\": [\n"
+        + "        {\n"
+        + "          \"code\": \"[LEGALREPRESENTATIVE]\",\n"
+        + "          \"label\": \"Legal Representative\"\n"
+        + "        }\n"
+        + "      ]\n"
+        + "    },\n"
+        + "    \"ApprovalStatus\": \"1\",\n"
+        + "    \"RequestTimestamp\": \"2021-03-03T15:43:55.779895\",\n"
+        + "    \"OrganisationToAdd\": {\n"
+        + "      \"OrganisationID\": \"8P7DJ0K\"\n"
+        + "    },\n"
+        + "    \"OrganisationToRemove\": {\n"
+        + "      \"OrganisationID\": \"7V6U9KC\"\n"
+        + "    }\n"
+        + "  }";
+    public static final String NULL_COR_NODE = "{\n"
+        + "    \"CaseRoleId\": {\n"
+        + "      \"value\": {\n"
+        + "        \"code\": \"[LEGALREPRESENTATIVE]\",\n"
+        + "        \"label\": \"Legal Representative\"\n"
+        + "      },\n"
+        + "      \"list_items\": [\n"
+        + "        {\n"
+        + "          \"code\": \"[LEGALREPRESENTATIVE]\",\n"
+        + "          \"label\": \"Legal Representative\"\n"
+        + "        }\n"
+        + "      ]\n"
+        + "    },\n"
+        + "    \"ApprovalStatus\": null,\n"
+        + "    \"RequestTimestamp\": null,\n"
+        + "    \"OrganisationToAdd\": {\n"
+        + "      \"OrganisationID\": null\n"
+        + "    },\n"
+        + "    \"OrganisationToRemove\": {\n"
+        + "      \"OrganisationID\": null\n"
+        + "    }\n"
+        + "  }";
 
+    public static final String CHANGE_ORGANISATION_REQUEST_FIELD = "changeOrganisationRequestField";
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
     private JacksonUtils jacksonUtils;
 
     @BeforeEach
@@ -68,6 +118,39 @@ class JacksonUtilsTest {
             + "\"ApprovalStatus\":null,\"RequestTimestamp\":null,\"OrganisationToAdd\":{\"OrganisationID\":null,"
             + "\"OrganisationName\":null},\"OrganisationToRemove\":{\"OrganisationID\":null,"
             + "\"OrganisationName\":null},\"ApprovalRejectionTimestamp\":null}");
+    }
+
+    @Test
+    void shouldMergeWhenCaseDataDoesNotHaveCorNode() throws JsonProcessingException {
+
+        Map<String, JsonNode> cordData = newHashMap(
+            CHANGE_ORGANISATION_REQUEST_FIELD,
+            objectMapper.readTree(COR_STRING)
+        );
+
+        JsonNode caseNodes = objectMapper.readTree("{\"name\": \"Sateesh\"}");
+        Map<String, JsonNode> caseData = newHashMap("person", caseNodes);
+
+        jacksonUtils.merge(cordData, caseData);
+
+        JSONAssert.assertEquals(caseData.get(CHANGE_ORGANISATION_REQUEST_FIELD).toString(),
+                                COR_STRING, LENIENT);
+    }
+
+    @Test
+    void shouldMergeWhenCaseDataHasNullCorNodes() throws JsonProcessingException {
+        Map<String, JsonNode> cordData = newHashMap(
+            CHANGE_ORGANISATION_REQUEST_FIELD,
+            objectMapper.readTree(COR_STRING)
+        );
+
+        JsonNode caseNodes = objectMapper.readTree(NULL_COR_NODE);
+        Map<String, JsonNode> caseData = newHashMap(CHANGE_ORGANISATION_REQUEST_FIELD, caseNodes);
+
+        jacksonUtils.merge(cordData, caseData);
+
+        JSONAssert.assertEquals(caseData.get(CHANGE_ORGANISATION_REQUEST_FIELD).toString(),
+                                COR_STRING, LENIENT);
     }
 
     @Nested

--- a/src/test/java/uk/gov/hmcts/reform/managecase/util/JacksonUtilsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/util/JacksonUtilsTest.java
@@ -37,6 +37,7 @@ class JacksonUtilsTest {
         + "      ]\n"
         + "    },\n"
         + "    \"ApprovalStatus\": \"1\",\n"
+        + "    \"NotesReason\": null,\n"
         + "    \"RequestTimestamp\": \"2021-03-03T15:43:55.779895\",\n"
         + "    \"OrganisationToAdd\": {\n"
         + "      \"OrganisationID\": \"8P7DJ0K\"\n"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDM-11407

Json merge has some issue dealing with nulls in NestedField in COR object. 
Options: 
1. We could you actually replace whole COR field ([commit](https://github.com/hmcts/aac-manage-case-assignment/pull/246/commits/d2d2b800ce7bcc83d897a6c2858e0d0706e06ef6) )
2. Fix the ordering of merge params and null check ([commit2](https://github.com/hmcts/aac-manage-case-assignment/pull/246/commits/47e6c2e47b5a3e9c12a61e04a157fdec82dfe1e4) [commit3](https://github.com/hmcts/aac-manage-case-assignment/pull/246/commits/bb698a2d9db015353fb1f1bc88ee6a90fad29bc2)
3. Not implemented - > we can actual set NULL for "OrganisationToAdd" and "OrganisationToRemove" after apply-noc-decision like [here](https://github.com/hmcts/aac-manage-case-assignment/blob/master/src/main/java/uk/gov/hmcts/reform/managecase/service/noc/ApplyNoCDecisionService.java#L112) 
  

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
