### PR TITLE
ACA-147 Update Assign access - switch from system to invoking user

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -229,6 +229,15 @@ ext.libraries = [
   ]
 ]
 
+// GOV.UK Notify has CVE-2021-29425 and transient dependency commons-io:commons-io needs updating
+// At the time latest is:
+// https://search.maven.org/artifact/uk.gov.service.notify/notifications-java-client/3.17.0-RELEASE/jar
+configurations.all {
+  resolutionStrategy {
+    force 'commons-io:commons-io:2.8.0'
+  }
+}
+
 dependencies {
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-web'

--- a/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/F-201 - Assign Access within Organisation.feature
+++ b/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/F-201 - Assign Access within Organisation.feature
@@ -23,6 +23,22 @@ Feature: F-201: Assign Access within Organisation
       And a call [by S2 to query his/her case roles granted over C1] will get the expected response as in [F-201_S2_Querying_Their_Access_Over_C1].
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  @S-201.1b
+  Scenario: Solicitor successfully sharing case access with another solicitor in their org (happy path) called with use_user_token to fetch case details
+
+    Given a user [S1 - a solicitor, to create a case under their organisation and share it with a fellow solicitor in the same organisation],
+      And a user [S2 - another solicitor in the same organisation, with whom S1 will share a case with an assignment within organisation],
+      And a case [C1, which S1 has just] created as in [F-201_Prerequisite_Case_Creation_C1],
+
+     When a request is prepared with appropriate values,
+      And the request [is to be invoked by S1 to assign access over C1 for S2 within the same organisation],
+      And it is submitted to call the [Assign Access within Organisation] operation of [Manage Case Assignment Microservice],
+
+     Then a positive response is received,
+      And the response has all other details as expected,
+      And a call [by S2 to query his/her case roles granted over C1] will get the expected response as in [F-201_S2_Querying_Their_Access_Over_C1].
+
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   @S-201.2
   Scenario: PUI CAA successfully sharing case access with another solicitor in their org (happy path)
 
@@ -38,6 +54,23 @@ Feature: F-201: Assign Access within Organisation
      Then a positive response is received,
       And the response has all other details as expected,
       And a call [by S2 to query his/her case roles granted over C1] will get the expected response as in [F-201_S2_Querying_Their_Access_Over_C1].
+
+#-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+  @S-201.2b
+  Scenario: Must return an error response if PUI CAA tries to share a case access with another solicitor in their org called with use_user_token, but has no case access
+
+    Given a user [S1 - a solicitor, to create a case under their organisation],
+      And a user [S2 - another solicitor in the same organisation, with whom a CAA will share a case with an assignment within organisation],
+      And a user [CAA - a PUI case access admin, to share a case with a solicitor in the same organisation],
+      And a case [C1, which S1 has just] created as in [F-201_Prerequisite_Case_Creation_C1],
+
+    When a request is prepared with appropriate values,
+      And the request [is to be invoked by CAA to assign access over C1 for S2 within the same organisation],
+      And it is submitted to call the [Assign Access within Organisation] operation of [Manage Case Assignment Microservice],
+
+    Then a negative response is received,
+      And the response has all the details as expected,
+      And a call [by S2 to query his/her case roles granted over C1] will get the expected response as in [F-201_S2_Querying_No_Access_Over_C1].
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
   @S-201.3

--- a/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/F-201-Base-useUserToken.td.json
+++ b/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/F-201-Base-useUserToken.td.json
@@ -1,0 +1,33 @@
+{
+	"_guid_": "F-201-Base-useUserToken",
+	"title": "Solicitor successfully sharing case access with another solicitor in their org (happy path)",
+
+	"productName": "Manage Case Assignment Microservice",
+	"operationName": "Assign Access within Organisation",
+
+	"method": "POST",
+	"uri": "/case-assignments?use_user_token=true",
+
+	"s2sClientId": "xui_webapp",
+	"userTokenClientId": "xuiwebapp",
+
+	"users": {
+		"S1": {
+			"username": "befta.master.solicitor.becky@gmail.com",
+			"password": "[[$CCD_BEFTA_MASTER_SOLICITOR_1_PWD]]"
+		},
+		"S2": {
+			"username": "befta.master.solicitor.benjamin@gmail.com",
+			"password": "[[$CCD_BEFTA_MASTER_SOLICITOR_2_PWD]]"
+		}
+	},
+
+	"request": {
+		"_extends_": "Common_Request",
+		"body": {
+			"case_type_id": "${[scenarioContext][childContexts][F-201_Prerequisite_Case_Creation_C1][testData][actualResponse][body][case_type_id]}",
+			"case_id": "${[scenarioContext][childContexts][F-201_Prerequisite_Case_Creation_C1][testData][actualResponse][body][id]}",
+			"assignee_id": "${[scenarioContext][testData][users][S2][id]}"
+		}
+	}
+}

--- a/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/S-201.1b.td.json
+++ b/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/S-201.1b.td.json
@@ -1,0 +1,18 @@
+{
+	"_guid_": "S-201.1b",
+	"_extends_": "F-201-Base-useUserToken",
+	"title": "Solicitor successfully sharing case access with another solicitor in their org (happy path) called with use_user_token to fetch case details",
+
+	"specs": [
+		"S1 - a solicitor, to create a case under their organisation and share it with a fellow solicitor in the same organisation",
+		"S2 - another solicitor in the same organisation, with whom S1 will share a case with an assignment within organisation",
+		"is to be invoked by S1 to assign access over C1 for S2 within the same organisation"
+	],
+
+	"expectedResponse": {
+		"_extends_": "Common_201_Response",
+		"body": {
+			"status_message": "Roles [Defendant],[Claimant] from the organisation policies successfully assigned to the assignee."
+		}
+	}
+}

--- a/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/S-201.2b.td.json
+++ b/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/S-201.2b.td.json
@@ -1,0 +1,27 @@
+{
+	"_guid_": "S-201.2b",
+	"_extends_": "F-201-Base-useUserToken",
+	"title": "Must return an error response if PUI CAA tries to share a case access with another solicitor in their org called with use_user_token, but has no case access",
+
+	"specs": [
+		"S1 - a solicitor, to create a case under their organisation",
+		"S2 - another solicitor in the same organisation, with whom a CAA will share a case with an assignment within organisation",
+		"CAA - a PUI case access admin, to share a case with a solicitor in the same organisation",
+		"is to be invoked by CAA to assign access over C1 for S2 within the same organisation"
+	],
+
+	"users": {
+		"invokingUser": {
+			"username": "befta.pui.caa.1@gmail.com",
+			"password": "[[$CCD_BEFTA_PUI_CAA_1_PWD]]"
+		}
+	},
+
+	"expectedResponse": {
+		"_extends_": "ACA_404_Response",
+    "body": {
+      "message": "Case could not be found",
+      "errors": []
+    }
+	}
+}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/managecase/fixtures/WiremockFixtures.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/managecase/fixtures/WiremockFixtures.java
@@ -51,7 +51,6 @@ public class WiremockFixtures {
     public static final String SERVICE_AUTHORIZATION = "ServiceAuthorization";
     public static final String SYS_USER_TOKEN = "Bearer eyJzdWIiOiJjY2RfZ3ciLCJleHAiOjE1ODM0NDUyOTd9aa";
     public static final String APPROVER_USER_TOKEN = "Bearer eyJzdWIiOiJjY6ShZ3ciLCJleHAiOlD1OEM0NDUyOTd7co";
-    public static final String INVOKING_USER_TOKEN = "Bearer eyJzdWIiOiJjY6ShZ3ciLCJleHAiOlD1OEM0NDUyOTd9bb";
     public static final String S2S_TOKEN = "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJjY2RfZ3ciLCJleHAiOjE1ODM0NDUyOTd9"
         + ".WWRzROlKxLQCJw5h0h0dHb9hHfbBhF2Idwv1z4L4FnqSw3VZ38ZRLuDmwr3tj-8oOv6EfLAxV0dJAPtUT203Iw";
 

--- a/src/integrationTest/java/uk/gov/hmcts/reform/managecase/fixtures/WiremockFixtures.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/managecase/fixtures/WiremockFixtures.java
@@ -51,6 +51,7 @@ public class WiremockFixtures {
     public static final String SERVICE_AUTHORIZATION = "ServiceAuthorization";
     public static final String SYS_USER_TOKEN = "Bearer eyJzdWIiOiJjY2RfZ3ciLCJleHAiOjE1ODM0NDUyOTd9aa";
     public static final String APPROVER_USER_TOKEN = "Bearer eyJzdWIiOiJjY6ShZ3ciLCJleHAiOlD1OEM0NDUyOTd7co";
+    public static final String INVOKING_USER_TOKEN = "Bearer eyJzdWIiOiJjY6ShZ3ciLCJleHAiOlD1OEM0NDUyOTd9bb";
     public static final String S2S_TOKEN = "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJjY2RfZ3ciLCJleHAiOjE1ODM0NDUyOTd9"
         + ".WWRzROlKxLQCJw5h0h0dHb9hHfbBhF2Idwv1z4L4FnqSw3VZ38ZRLuDmwr3tj-8oOv6EfLAxV0dJAPtUT203Iw";
 
@@ -302,7 +303,6 @@ public class WiremockFixtures {
 
     public static void stubGetCaseDetailsByCaseIdViaExternalApi(String caseId, CaseDetails caseDetails) {
         stubFor(WireMock.get(urlEqualTo(CASES + caseId))
-                    .withHeader(AUTHORIZATION, equalTo(SYS_USER_TOKEN))
                     .withHeader(SERVICE_AUTHORIZATION, equalTo(S2S_TOKEN))
                     .willReturn(aResponse()
                                     .withStatus(caseDetails == null ? HTTP_NOT_FOUND : HTTP_OK)

--- a/src/main/java/uk/gov/hmcts/reform/managecase/api/controller/CaseAssignmentController.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/api/controller/CaseAssignmentController.java
@@ -34,6 +34,7 @@ import javax.validation.ValidationException;
 import javax.validation.constraints.NotEmpty;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
@@ -102,9 +103,10 @@ public class CaseAssignmentController {
         )
     })
     public CaseAssignmentResponse assignAccessWithinOrganisation(
-            @Valid @RequestBody CaseAssignmentRequest requestPayload) {
+            @Valid @RequestBody CaseAssignmentRequest requestPayload,
+            @RequestParam(name = "use_user_token", required = false) Optional<Boolean> useUserToken) {
         CaseAssignment caseAssignment = mapper.map(requestPayload, CaseAssignment.class);
-        List<String> roles = caseAssignmentService.assignCaseAccess(caseAssignment);
+        List<String> roles = caseAssignmentService.assignCaseAccess(caseAssignment, useUserToken.orElse(false));
         return new CaseAssignmentResponse(String.format(ASSIGN_ACCESS_MESSAGE, StringUtils.join(roles, ',')));
     }
 

--- a/src/main/java/uk/gov/hmcts/reform/managecase/client/datastore/DataStoreApiClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/client/datastore/DataStoreApiClient.java
@@ -63,6 +63,6 @@ public interface DataStoreApiClient {
                                     @RequestBody CaseEventCreationPayload caseEventCreationPayload);
 
     @GetMapping(CASES_WITH_ID)
-    CaseDetails getCaseDetailsByCaseIdViaExternalApi(@PathVariable(CASE_ID) String caseId);
-
+    CaseDetails getCaseDetailsByCaseIdViaExternalApi(@RequestHeader(AUTHORIZATION) String userAuthorizationHeader,
+                                                     @PathVariable(CASE_ID) String caseId);
 }

--- a/src/main/java/uk/gov/hmcts/reform/managecase/repository/DataStoreRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/repository/DataStoreRepository.java
@@ -30,5 +30,7 @@ public interface DataStoreRepository {
 
     CaseDetails submitEventForCase(String caseId, CaseEventCreationPayload caseEventCreationPayload);
 
-    CaseDetails findCaseByCaseIdExternalApi(String caseId);
+    CaseDetails findCaseByCaseIdUsingExternalApi(String caseId);
+
+    CaseDetails findCaseByCaseIdAsSystemUserUsingExternalApi(String caseId);
 }

--- a/src/main/java/uk/gov/hmcts/reform/managecase/repository/DefaultDataStoreRepository.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/repository/DefaultDataStoreRepository.java
@@ -209,7 +209,7 @@ public class DefaultDataStoreRepository implements DataStoreRepository {
             if (asSystemUser) {
                 return dataStoreApi.getCaseDetailsByCaseIdViaExternalApi(securityUtils.getCaaSystemUserToken(), caseId);
             } else {
-                return dataStoreApi.getCaseDetailsByCaseIdViaExternalApi(securityUtils.getUserToken(), caseId);
+                return dataStoreApi.getCaseDetailsByCaseIdViaExternalApi(securityUtils.getUserBearerToken(), caseId);
             }
         } catch (FeignException e) {
             if (HttpStatus.NOT_FOUND.value() == e.status()) {

--- a/src/main/java/uk/gov/hmcts/reform/managecase/service/CaseAssignmentService.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/service/CaseAssignmentService.java
@@ -194,7 +194,7 @@ public class CaseAssignmentService {
     }
 
     private CaseDetails getCase(CaseAssignment input) {
-        return dataStoreRepository.findCaseByCaseIdExternalApi(input.getCaseId());
+        return dataStoreRepository.findCaseByCaseIdUsingExternalApi(input.getCaseId());
     }
 
     private List<String> findInvokerOrgPolicyRoles(CaseDetails caseDetails, String organisation) {

--- a/src/main/java/uk/gov/hmcts/reform/managecase/service/noc/NoticeOfChangeQuestions.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/service/noc/NoticeOfChangeQuestions.java
@@ -71,7 +71,7 @@ public class NoticeOfChangeQuestions {
         CaseViewResource caseViewResource = dataStoreRepository.findCaseByCaseId(caseId);
         checkForCaseEvents(caseViewResource);
 
-        CaseDetails caseDetails = dataStoreRepository.findCaseByCaseIdExternalApi(caseId);
+        CaseDetails caseDetails = dataStoreRepository.findCaseByCaseIdAsSystemUserUsingExternalApi(caseId);
         checkCaseFields(caseDetails);
         validateUserRoles(caseDetails.getJurisdiction(), getUserInfo());
         ChallengeQuestionsResult challengeQuestionsResult =

--- a/src/main/java/uk/gov/hmcts/reform/managecase/service/noc/RequestNoticeOfChangeService.java
+++ b/src/main/java/uk/gov/hmcts/reform/managecase/service/noc/RequestNoticeOfChangeService.java
@@ -129,7 +129,7 @@ public class RequestNoticeOfChangeService {
     }
 
     private CaseDetails getCaseViaExternalApi(String caseId) {
-        return dataStoreRepository.findCaseByCaseIdExternalApi(caseId);
+        return dataStoreRepository.findCaseByCaseIdAsSystemUserUsingExternalApi(caseId);
     }
 
     private String getEventId(NoCRequestDetails noCRequestDetails) {

--- a/src/test/java/uk/gov/hmcts/reform/managecase/repository/DataStoreRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/repository/DataStoreRepositoryTest.java
@@ -81,6 +81,7 @@ class DataStoreRepositoryTest {
     private static final String EVENT_TOKEN = "eventToken";
 
     public static final String USER_TOKEN = "Bearer user Token";
+    public static final String SYSTEM_USER_TOKEN = "Bearer system user Token";
 
     private static final String JURISDICTION = "Jurisdiction";
 
@@ -99,46 +100,49 @@ class DataStoreRepositoryTest {
     @BeforeEach
     void setUp() {
         initMocks(this);
-        given(securityUtils.getCaaSystemUserToken()).willReturn(USER_TOKEN);
+        given(securityUtils.getCaaSystemUserToken()).willReturn(SYSTEM_USER_TOKEN);
     }
 
     @Test
-    @DisplayName("find case by id using external facing API")
-    void shouldFindCaseByIdUsingExternalApi() {
+    @DisplayName("find case by id as an invoking user using external facing API")
+    void shouldFindCaseByCaseIdUsingExternalApi() {
         // ARRANGE
         CaseDetails caseDetails = CaseDetails.builder()
             .caseTypeId(CASE_TYPE_ID)
             .id(CASE_ID)
             .build();
-        given(dataStoreApi.getCaseDetailsByCaseIdViaExternalApi(CASE_ID)).willReturn(caseDetails);
+        given(securityUtils.getUserToken()).willReturn(USER_TOKEN);
+        given(dataStoreApi.getCaseDetailsByCaseIdViaExternalApi(USER_TOKEN, CASE_ID)).willReturn(caseDetails);
 
         // ACT
-        CaseDetails result = repository.findCaseByCaseIdExternalApi(CASE_ID);
+        CaseDetails result = repository.findCaseByCaseIdUsingExternalApi(CASE_ID);
 
         // ASSERT
         assertThat(result).isEqualTo(caseDetails);
-        verify(dataStoreApi).getCaseDetailsByCaseIdViaExternalApi(eq(CASE_ID));
+        verify(dataStoreApi).getCaseDetailsByCaseIdViaExternalApi(eq(USER_TOKEN), eq(CASE_ID));
     }
 
     @Test
-    @DisplayName("find case by id using external facing API return no cases")
-    void shouldReturnNoCaseForFindCaseByIdUsingExternalApi() {
+    @DisplayName("find case by id as an invoking user using external facing API return no cases")
+    void shouldReturnNoCaseForFindCaseByCaseIdUsingExternalApi() {
         // ARRANGE
-        given(dataStoreApi.getCaseDetailsByCaseIdViaExternalApi(CASE_ID)).willReturn(null);
+        given(securityUtils.getUserToken()).willReturn(USER_TOKEN);
+        given(dataStoreApi.getCaseDetailsByCaseIdViaExternalApi(USER_TOKEN, CASE_ID)).willReturn(null);
 
         // ACT
-        CaseDetails result = repository.findCaseByCaseIdExternalApi(CASE_ID);
+        CaseDetails result = repository.findCaseByCaseIdUsingExternalApi(CASE_ID);
 
         // ASSERT
         assertThat(result).isNull();
-        verify(dataStoreApi).getCaseDetailsByCaseIdViaExternalApi(eq(CASE_ID));
+        verify(dataStoreApi).getCaseDetailsByCaseIdViaExternalApi(eq(USER_TOKEN), eq(CASE_ID));
     }
 
     @Test
-    @DisplayName("find case by id using external facing API throws CaseCouldNotBeFetchedException")
-    void shouldThrowCaseCouldNotBeFetchedExceptionForFindCaseByIdUsingExternalApi() {
+    @DisplayName("find case by id as an invoking user using external facing API throws CaseCouldNotBeFetchedException")
+    void shouldThrowCaseCouldNotBeFetchedExceptionForFindCaseByCaseIdUsingExternalApi() {
         // ARRANGE
-        given(dataStoreApi.getCaseDetailsByCaseIdViaExternalApi(CASE_ID))
+        given(securityUtils.getUserToken()).willReturn(USER_TOKEN);
+        given(dataStoreApi.getCaseDetailsByCaseIdViaExternalApi(USER_TOKEN, CASE_ID))
             .willThrow(new FeignException.NotFound("404",
                                                    Request.create(Request.HttpMethod.GET, "someUrl", Map.of(),
                                                                   null, Charset.defaultCharset(),
@@ -147,7 +151,57 @@ class DataStoreRepositoryTest {
             ));
 
         // ACT & ASSERT
-        assertThatThrownBy(() -> repository.findCaseByCaseIdExternalApi(CASE_ID))
+        assertThatThrownBy(() -> repository.findCaseByCaseIdUsingExternalApi(CASE_ID))
+            .isInstanceOf(CaseCouldNotBeFoundException.class)
+            .hasMessageContaining(CASE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("find case by id as a system user using external facing API")
+    void shouldFindCaseByCaseIdAsSystemUserUsingExternalApi() {
+        // ARRANGE
+        CaseDetails caseDetails = CaseDetails.builder()
+            .caseTypeId(CASE_TYPE_ID)
+            .id(CASE_ID)
+            .build();
+        given(dataStoreApi.getCaseDetailsByCaseIdViaExternalApi(SYSTEM_USER_TOKEN, CASE_ID)).willReturn(caseDetails);
+
+        // ACT
+        CaseDetails result = repository.findCaseByCaseIdAsSystemUserUsingExternalApi(CASE_ID);
+
+        // ASSERT
+        assertThat(result).isEqualTo(caseDetails);
+        verify(dataStoreApi).getCaseDetailsByCaseIdViaExternalApi(eq(SYSTEM_USER_TOKEN), eq(CASE_ID));
+    }
+
+    @Test
+    @DisplayName("find case by id as a system user using external facing API return no cases")
+    void shouldReturnNoCaseForFindCaseByCaseIdAsSystemUserUsingExternalApi() {
+        // ARRANGE
+        given(dataStoreApi.getCaseDetailsByCaseIdViaExternalApi(SYSTEM_USER_TOKEN, CASE_ID)).willReturn(null);
+
+        // ACT
+        CaseDetails result = repository.findCaseByCaseIdAsSystemUserUsingExternalApi(CASE_ID);
+
+        // ASSERT
+        assertThat(result).isNull();
+        verify(dataStoreApi).getCaseDetailsByCaseIdViaExternalApi(eq(SYSTEM_USER_TOKEN), eq(CASE_ID));
+    }
+
+    @Test
+    @DisplayName("find case by id as a system user using external facing API throws CaseCouldNotBeFetchedException")
+    void shouldThrowCaseCouldNotBeFetchedExceptionForFindCaseByCaseIdAsSystemUserUsingExternalApi() {
+        // ARRANGE
+        given(dataStoreApi.getCaseDetailsByCaseIdViaExternalApi(SYSTEM_USER_TOKEN, CASE_ID))
+            .willThrow(new FeignException.NotFound("404",
+                                                   Request.create(Request.HttpMethod.GET, "someUrl", Map.of(),
+                                                                  null, Charset.defaultCharset(),
+                                                                  null
+                                                   ), null
+            ));
+
+        // ACT & ASSERT
+        assertThatThrownBy(() -> repository.findCaseByCaseIdAsSystemUserUsingExternalApi(CASE_ID))
             .isInstanceOf(CaseCouldNotBeFoundException.class)
             .hasMessageContaining(CASE_NOT_FOUND);
     }
@@ -292,7 +346,7 @@ class DataStoreRepositoryTest {
     void shouldReturnCaseUpdateViewEventWhenStartEventTriggerSucceeds() {
         CaseUpdateViewEvent caseUpdateViewEvent = CaseUpdateViewEvent.builder().build();
 
-        given(dataStoreApi.getStartEventTrigger(USER_TOKEN, CASE_ID, EVENT_ID))
+        given(dataStoreApi.getStartEventTrigger(SYSTEM_USER_TOKEN, CASE_ID, EVENT_ID))
             .willReturn(caseUpdateViewEvent);
 
         CaseUpdateViewEvent returnedCaseUpdateViewEvent
@@ -304,7 +358,7 @@ class DataStoreRepositoryTest {
     @Test
     @DisplayName("getStartEventTrigger returns null")
     void shouldReturnNullCaseResourceOnStartEventTrigger() {
-        given(dataStoreApi.getStartEventTrigger(USER_TOKEN, CASE_ID, EVENT_ID))
+        given(dataStoreApi.getStartEventTrigger(SYSTEM_USER_TOKEN, CASE_ID, EVENT_ID))
             .willReturn(null);
 
         CaseUpdateViewEvent returnedCaseUpdateViewEvent
@@ -320,7 +374,7 @@ class DataStoreRepositoryTest {
             .callbackResponseStatus(INCOMPLETE_CALLBACK)
             .build();
 
-        given(dataStoreApi.submitEventForCase(eq(USER_TOKEN), eq(CASE_ID), any(CaseEventCreationPayload.class)))
+        given(dataStoreApi.submitEventForCase(eq(SYSTEM_USER_TOKEN), eq(CASE_ID), any(CaseEventCreationPayload.class)))
             .willReturn(caseDetails);
 
         assertThatThrownBy(() -> repository.submitEventForCase(CASE_ID, CaseEventCreationPayload.builder().build()))
@@ -334,7 +388,7 @@ class DataStoreRepositoryTest {
         CaseEventCreationPayload caseEventCreationPayload = CaseEventCreationPayload.builder().build();
         CaseDetails caseDetails = CaseDetails.builder().build();
 
-        given(dataStoreApi.submitEventForCase(eq(USER_TOKEN), eq(CASE_ID), any(CaseEventCreationPayload.class)))
+        given(dataStoreApi.submitEventForCase(eq(SYSTEM_USER_TOKEN), eq(CASE_ID), any(CaseEventCreationPayload.class)))
             .willReturn(caseDetails);
 
         CaseDetails returnedCaseDetails
@@ -349,7 +403,7 @@ class DataStoreRepositoryTest {
         // ARRANGE
         ChangeOrganisationRequest changeOrganisationRequest = ChangeOrganisationRequest.builder().build();
 
-        given(dataStoreApi.getStartEventTrigger(USER_TOKEN, CASE_ID, EVENT_ID))
+        given(dataStoreApi.getStartEventTrigger(SYSTEM_USER_TOKEN, CASE_ID, EVENT_ID))
             .willReturn(null);
 
         // ACT
@@ -357,7 +411,7 @@ class DataStoreRepositoryTest {
             = repository.submitNoticeOfChangeRequestEvent(CASE_ID, EVENT_ID, changeOrganisationRequest);
 
         // ASSERT
-        verify(dataStoreApi).getStartEventTrigger(USER_TOKEN, CASE_ID, EVENT_ID);
+        verify(dataStoreApi).getStartEventTrigger(SYSTEM_USER_TOKEN, CASE_ID, EVENT_ID);
         verify(dataStoreApi, never()).submitEventForCase(any(), any(), any());
         assertThat(caseDetails).isNull();
     }
@@ -372,7 +426,7 @@ class DataStoreRepositoryTest {
             .caseFields(getCaseViewFields())
             .build();
 
-        given(dataStoreApi.getStartEventTrigger(USER_TOKEN, CASE_ID, EVENT_ID)).willReturn(caseUpdateViewEvent);
+        given(dataStoreApi.getStartEventTrigger(SYSTEM_USER_TOKEN, CASE_ID, EVENT_ID)).willReturn(caseUpdateViewEvent);
 
         ObjectMapper mapper = new ObjectMapper();
 
@@ -385,7 +439,8 @@ class DataStoreRepositoryTest {
             .caseDetails(caseDetails)
             .build();
 
-        given(dataStoreApi.getExternalStartEventTrigger(USER_TOKEN, CASE_ID, EVENT_ID)).willReturn(startEventResource);
+        given(dataStoreApi.getExternalStartEventTrigger(SYSTEM_USER_TOKEN, CASE_ID, EVENT_ID))
+            .willReturn(startEventResource);
 
         given(dataStoreApi.submitEventForCase(any(String.class), any(String.class),
             any(CaseEventCreationPayload.class))).willReturn(CaseDetails.builder().build());
@@ -404,7 +459,7 @@ class DataStoreRepositoryTest {
         repository.submitNoticeOfChangeRequestEvent(CASE_ID, EVENT_ID, changeOrganisationRequest);
 
         // ASSERT
-        verify(dataStoreApi).getStartEventTrigger(USER_TOKEN, CASE_ID, EVENT_ID);
+        verify(dataStoreApi).getStartEventTrigger(SYSTEM_USER_TOKEN, CASE_ID, EVENT_ID);
         ArgumentCaptor<CaseEventCreationPayload> captor = ArgumentCaptor.forClass(CaseEventCreationPayload.class);
         verify(dataStoreApi).submitEventForCase(any(String.class), any(String.class), captor.capture());
 
@@ -428,7 +483,7 @@ class DataStoreRepositoryTest {
             .wizardPages(getWizardPages("testCVaseField"))
             .build();
 
-        given(dataStoreApi.getStartEventTrigger(USER_TOKEN, CASE_ID, EVENT_ID)).willReturn(caseUpdateViewEvent);
+        given(dataStoreApi.getStartEventTrigger(SYSTEM_USER_TOKEN, CASE_ID, EVENT_ID)).willReturn(caseUpdateViewEvent);
 
         // ACT & ASSERT
         IllegalStateException illegalStateException = assertThrows(IllegalStateException.class, () ->
@@ -446,7 +501,7 @@ class DataStoreRepositoryTest {
     void shouldThrowExceptionWhenSubmitEventForCaseCalledWithoutCaseViewField() {
 
         // ARRANGE
-        given(dataStoreApi.getStartEventTrigger(USER_TOKEN, CASE_ID, EVENT_ID))
+        given(dataStoreApi.getStartEventTrigger(SYSTEM_USER_TOKEN, CASE_ID, EVENT_ID))
             .willReturn(CaseUpdateViewEvent.builder()
                             .eventToken("eventToken")
                             .build());
@@ -459,7 +514,7 @@ class DataStoreRepositoryTest {
         assertThat(illegalStateException.getMessage()).isEqualTo(CHANGE_ORGANISATION_REQUEST_MISSING_CASE_FIELD_ID);
 
         // ASSERT
-        verify(dataStoreApi).getStartEventTrigger(USER_TOKEN, CASE_ID, EVENT_ID);
+        verify(dataStoreApi).getStartEventTrigger(SYSTEM_USER_TOKEN, CASE_ID, EVENT_ID);
         verify(dataStoreApi, never()).submitEventForCase(any(), any(), any());
     }
 
@@ -474,12 +529,13 @@ class DataStoreRepositoryTest {
             .caseFields(getCaseViewFields())
             .build();
 
-        given(dataStoreApi.getStartEventTrigger(USER_TOKEN, CASE_ID, EVENT_ID)).willReturn(caseUpdateViewEvent);
+        given(dataStoreApi.getStartEventTrigger(SYSTEM_USER_TOKEN, CASE_ID, EVENT_ID)).willReturn(caseUpdateViewEvent);
 
         StartEventResource startEventResource = StartEventResource.builder()
             .caseDetails(CaseDetails.builder().data(new HashMap<>()).build())
             .build();
-        given(dataStoreApi.getExternalStartEventTrigger(USER_TOKEN, CASE_ID, EVENT_ID)).willReturn(startEventResource);
+        given(dataStoreApi.getExternalStartEventTrigger(SYSTEM_USER_TOKEN, CASE_ID, EVENT_ID))
+            .willReturn(startEventResource);
 
         given(dataStoreApi.submitEventForCase(any(String.class),
                                               any(String.class),
@@ -508,7 +564,8 @@ class DataStoreRepositoryTest {
                                               any(CaseEventCreationPayload.class)))
             .willReturn(CaseDetails.builder().data(data).build());
 
-        given(dataStoreApi.getExternalStartEventTrigger(USER_TOKEN, CASE_ID, EVENT_ID)).willReturn(startEventResource);
+        given(dataStoreApi.getExternalStartEventTrigger(SYSTEM_USER_TOKEN, CASE_ID, EVENT_ID))
+            .willReturn(startEventResource);
 
         // ACT
         repository.submitNoticeOfChangeRequestEvent(CASE_ID, EVENT_ID, ChangeOrganisationRequest.builder().build());
@@ -527,12 +584,13 @@ class DataStoreRepositoryTest {
             .caseFields(getCaseViewFields())
             .build();
 
-        given(dataStoreApi.getStartEventTrigger(USER_TOKEN, CASE_ID, EVENT_ID)).willReturn(caseUpdateViewEvent);
+        given(dataStoreApi.getStartEventTrigger(SYSTEM_USER_TOKEN, CASE_ID, EVENT_ID)).willReturn(caseUpdateViewEvent);
 
         StartEventResource startEventResource = StartEventResource.builder()
             .caseDetails(CaseDetails.builder().data(new HashMap<>()).build())
             .build();
-        given(dataStoreApi.getExternalStartEventTrigger(USER_TOKEN, CASE_ID, EVENT_ID)).willReturn(startEventResource);
+        given(dataStoreApi.getExternalStartEventTrigger(SYSTEM_USER_TOKEN, CASE_ID, EVENT_ID))
+            .willReturn(startEventResource);
 
         given(dataStoreApi.submitEventForCase(any(String.class), any(String.class),any(CaseEventCreationPayload.class)))
             .willReturn(CaseDetails.builder()

--- a/src/test/java/uk/gov/hmcts/reform/managecase/repository/DataStoreRepositoryTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/repository/DataStoreRepositoryTest.java
@@ -111,7 +111,7 @@ class DataStoreRepositoryTest {
             .caseTypeId(CASE_TYPE_ID)
             .id(CASE_ID)
             .build();
-        given(securityUtils.getUserToken()).willReturn(USER_TOKEN);
+        given(securityUtils.getUserBearerToken()).willReturn(USER_TOKEN);
         given(dataStoreApi.getCaseDetailsByCaseIdViaExternalApi(USER_TOKEN, CASE_ID)).willReturn(caseDetails);
 
         // ACT
@@ -126,7 +126,7 @@ class DataStoreRepositoryTest {
     @DisplayName("find case by id as an invoking user using external facing API return no cases")
     void shouldReturnNoCaseForFindCaseByCaseIdUsingExternalApi() {
         // ARRANGE
-        given(securityUtils.getUserToken()).willReturn(USER_TOKEN);
+        given(securityUtils.getUserBearerToken()).willReturn(USER_TOKEN);
         given(dataStoreApi.getCaseDetailsByCaseIdViaExternalApi(USER_TOKEN, CASE_ID)).willReturn(null);
 
         // ACT
@@ -141,7 +141,7 @@ class DataStoreRepositoryTest {
     @DisplayName("find case by id as an invoking user using external facing API throws CaseCouldNotBeFetchedException")
     void shouldThrowCaseCouldNotBeFetchedExceptionForFindCaseByCaseIdUsingExternalApi() {
         // ARRANGE
-        given(securityUtils.getUserToken()).willReturn(USER_TOKEN);
+        given(securityUtils.getUserBearerToken()).willReturn(USER_TOKEN);
         given(dataStoreApi.getCaseDetailsByCaseIdViaExternalApi(USER_TOKEN, CASE_ID))
             .willThrow(new FeignException.NotFound("404",
                                                    Request.create(Request.HttpMethod.GET, "someUrl", Map.of(),

--- a/src/test/java/uk/gov/hmcts/reform/managecase/service/CaseAssignmentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/service/CaseAssignmentServiceTest.java
@@ -10,7 +10,6 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import uk.gov.hmcts.reform.idam.client.models.UserDetails;
-import uk.gov.hmcts.reform.idam.client.models.UserInfo;
 import uk.gov.hmcts.reform.managecase.TestFixtures;
 import uk.gov.hmcts.reform.managecase.api.errorhandling.CaseCouldNotBeFoundException;
 import uk.gov.hmcts.reform.managecase.api.errorhandling.ValidationError;
@@ -59,8 +58,6 @@ class CaseAssignmentServiceTest {
     private static final String CASE_ID2 = "87654321";
     private static final String ORG_POLICY_ROLE = "caseworker-probate";
     private static final String ORG_POLICY_ROLE2 = "caseworker-probate2";
-    private static final String PROBATE_SOLICITOR_ROLE = "caseworker-probate-solicitor";
-    private static final String PUI_CAA_ROLE = "pui-caa";
     private static final String CASE_ROLE = "[CR1]";
     private static final String CASE_ROLE2 = "[CR2]";
     private static final String ORGANIZATION_ID = "TEST_ORG";
@@ -100,7 +97,6 @@ class CaseAssignmentServiceTest {
                 .willReturn(caseDetails(ORGANIZATION_ID, ORG_POLICY_ROLE));
             given(prdRepository.findUsersByOrganisation())
                 .willReturn(usersByOrganisation(user(ASSIGNEE_ID)));
-            given(securityUtils.getUserInfo()).willReturn(userInfoWithRole(PROBATE_SOLICITOR_ROLE));
             given(securityUtils.hasSolicitorRole(anyList())).willReturn(true);
 
             UserDetails userDetails = UserDetails.builder()
@@ -121,21 +117,21 @@ class CaseAssignmentServiceTest {
                 .willReturn(organisationPolicy(ORGANIZATION_ID, ORG_POLICY_ROLE))
                 .willReturn(organisationPolicy(ORGANIZATION_ID, ORG_POLICY_ROLE2));
 
-            List<String> roles = service.assignCaseAccess(caseAssignment);
+            List<String> roles = service.assignCaseAccess(caseAssignment, true);
 
             assertThat(roles).containsExactly(ORG_POLICY_ROLE, ORG_POLICY_ROLE2);
 
             verify(dataStoreRepository)
                 .assignCase(List.of(ORG_POLICY_ROLE, ORG_POLICY_ROLE2), CASE_ID, ASSIGNEE_ID, ORGANIZATION_ID);
+            verify(dataStoreRepository)
+                .findCaseByCaseIdUsingExternalApi(CASE_ID);
         }
 
         @Test
         @DisplayName("should assign case in the organisation when invoked by non solicitor user")
         void shouldAssignCaseAccessWhenInvokedByNonSolicitorUser() {
 
-            given(securityUtils.getUserInfo()).willReturn(userInfoWithRole(PUI_CAA_ROLE));
             given(securityUtils.hasSolicitorAndJurisdictionRoles(anyList(), anyString())).willReturn(true);
-            given(securityUtils.hasSolicitorRole(anyList())).willReturn(false);
             given(dataStoreRepository.findCaseByCaseIdAsSystemUserUsingExternalApi(CASE_ID))
                 .willReturn(caseDetails(ORGANIZATION_ID, ORG_POLICY_ROLE, ORG_POLICY_ROLE2));
 
@@ -143,12 +139,14 @@ class CaseAssignmentServiceTest {
                 .willReturn(organisationPolicy(ORGANIZATION_ID, ORG_POLICY_ROLE))
                 .willReturn(organisationPolicy(ORGANIZATION_ID, ORG_POLICY_ROLE2));
 
-            List<String> roles = service.assignCaseAccess(caseAssignment);
+            List<String> roles = service.assignCaseAccess(caseAssignment, false);
 
             assertThat(roles).containsExactly(ORG_POLICY_ROLE, ORG_POLICY_ROLE2);
 
             verify(dataStoreRepository)
                 .assignCase(List.of(ORG_POLICY_ROLE, ORG_POLICY_ROLE2), CASE_ID, ASSIGNEE_ID, ORGANIZATION_ID);
+            verify(dataStoreRepository)
+                .findCaseByCaseIdAsSystemUserUsingExternalApi(CASE_ID);
         }
 
         @Test
@@ -158,7 +156,7 @@ class CaseAssignmentServiceTest {
             given(dataStoreRepository.findCaseByCaseIdUsingExternalApi(CASE_ID))
                 .willThrow(new CaseCouldNotBeFoundException(CASE_NOT_FOUND));
 
-            assertThatThrownBy(() -> service.assignCaseAccess(caseAssignment))
+            assertThatThrownBy(() -> service.assignCaseAccess(caseAssignment, true))
                 .isInstanceOf(CaseCouldNotBeFoundException.class)
                 .hasMessageContaining(CASE_NOT_FOUND);
         }
@@ -170,7 +168,7 @@ class CaseAssignmentServiceTest {
             given(prdRepository.findUsersByOrganisation())
                 .willReturn(usersByOrganisation(user(ANOTHER_USER)));
 
-            assertThatThrownBy(() -> service.assignCaseAccess(caseAssignment))
+            assertThatThrownBy(() -> service.assignCaseAccess(caseAssignment, true))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining(ValidationError.ASSIGNEE_ORGANISATION_ERROR);
         }
@@ -184,13 +182,9 @@ class CaseAssignmentServiceTest {
 
             given(idamRepository.getUserByUserId(ASSIGNEE_ID, BEAR_TOKEN)).willReturn(userDetails);
 
-            assertThatThrownBy(() -> service.assignCaseAccess(caseAssignment))
+            assertThatThrownBy(() -> service.assignCaseAccess(caseAssignment, true))
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining(ValidationError.ASSIGNEE_ROLE_ERROR);
-        }
-
-        private UserInfo userInfoWithRole(String puiCaaRole) {
-            return UserInfo.builder().name("Jon").roles(List.of(puiCaaRole)).build();
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/managecase/service/CaseAssignmentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/service/CaseAssignmentServiceTest.java
@@ -93,7 +93,7 @@ class CaseAssignmentServiceTest {
         void setUp() {
             caseAssignment = new CaseAssignment(CASE_TYPE_ID, CASE_ID, ASSIGNEE_ID);
 
-            given(dataStoreRepository.findCaseByCaseIdExternalApi(CASE_ID))
+            given(dataStoreRepository.findCaseByCaseIdUsingExternalApi(CASE_ID))
                 .willReturn(caseDetails(ORGANIZATION_ID, ORG_POLICY_ROLE));
             given(prdRepository.findUsersByOrganisation())
                 .willReturn(usersByOrganisation(user(ASSIGNEE_ID)));
@@ -109,7 +109,7 @@ class CaseAssignmentServiceTest {
         void shouldAssignCaseAccess() {
 
             given(securityUtils.hasSolicitorAndJurisdictionRoles(anyList(), anyString())).willReturn(true);
-            given(dataStoreRepository.findCaseByCaseIdExternalApi(CASE_ID))
+            given(dataStoreRepository.findCaseByCaseIdUsingExternalApi(CASE_ID))
                 .willReturn(caseDetails(ORGANIZATION_ID, ORG_POLICY_ROLE, ORG_POLICY_ROLE2));
 
             given(jacksonUtils.convertValue(any(JsonNode.class), eq(OrganisationPolicy.class)))
@@ -128,7 +128,7 @@ class CaseAssignmentServiceTest {
         @DisplayName("should throw case could not be found error when case is not found")
         void shouldThrowCaseCouldNotBeFetchedException_whenCaseNotFound() {
 
-            given(dataStoreRepository.findCaseByCaseIdExternalApi(CASE_ID))
+            given(dataStoreRepository.findCaseByCaseIdUsingExternalApi(CASE_ID))
                 .willThrow(new CaseCouldNotBeFoundException(CASE_NOT_FOUND));
 
             assertThatThrownBy(() -> service.assignCaseAccess(caseAssignment))

--- a/src/test/java/uk/gov/hmcts/reform/managecase/service/noc/NoticeOfChangeQuestionsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/service/noc/NoticeOfChangeQuestionsTest.java
@@ -136,7 +136,7 @@ class NoticeOfChangeQuestionsTest {
 
             CaseDetails caseDetails = CaseDetails.builder().id(CASE_ID).caseTypeId(CASE_TYPE_ID).data(data).build();
 
-            given(dataStoreRepository.findCaseByCaseIdExternalApi(CASE_ID)).willReturn(caseDetails);
+            given(dataStoreRepository.findCaseByCaseIdAsSystemUserUsingExternalApi(CASE_ID)).willReturn(caseDetails);
             given(jacksonUtils.convertValue(any(JsonNode.class), eq(OrganisationPolicy.class)))
                 .willReturn(organisationPolicy(ORGANIZATION_ID, ORG_POLICY_ROLE));
 
@@ -248,7 +248,7 @@ class NoticeOfChangeQuestionsTest {
             CaseDetails caseDetails = CaseDetails.builder().id(CASE_ID).data(data).build();
 
             // external case by id
-            given(dataStoreRepository.findCaseByCaseIdExternalApi(CASE_ID)).willReturn(caseDetails);
+            given(dataStoreRepository.findCaseByCaseIdAsSystemUserUsingExternalApi(CASE_ID)).willReturn(caseDetails);
 
             assertThatThrownBy(() -> service.getChallengeQuestions(CASE_ID))
                 .isInstanceOf(NoCException.class)
@@ -276,7 +276,7 @@ class NoticeOfChangeQuestionsTest {
             CaseDetails caseDetails = CaseDetails.builder().id(CASE_ID).data(data).build();
 
             // external case by id
-            given(dataStoreRepository.findCaseByCaseIdExternalApi(CASE_ID)).willReturn(caseDetails);
+            given(dataStoreRepository.findCaseByCaseIdAsSystemUserUsingExternalApi(CASE_ID)).willReturn(caseDetails);
 
             assertThatThrownBy(() -> service.getChallengeQuestions(CASE_ID))
                 .isInstanceOf(NoCException.class)

--- a/src/test/java/uk/gov/hmcts/reform/managecase/service/noc/RequestNoticeOfChangeServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/managecase/service/noc/RequestNoticeOfChangeServiceTest.java
@@ -123,7 +123,7 @@ class RequestNoticeOfChangeServiceTest {
 
         caseDetails = CaseDetails.builder().id(CASE_ID).data(new HashMap<>()).build();
 
-        given(dataStoreRepository.findCaseByCaseIdExternalApi(CASE_ID)).willReturn(caseDetails);
+        given(dataStoreRepository.findCaseByCaseIdAsSystemUserUsingExternalApi(CASE_ID)).willReturn(caseDetails);
 
         List<CaseRole> caseRoles = List.of(CaseRole.builder().id(CASE_ASSIGNED_ROLE).name(DYNAMIC_LIST_LABEL).build());
         given(definitionStoreRepository.caseRoles(anyString(), anyString(), anyString())).willReturn(caseRoles);
@@ -199,7 +199,6 @@ class RequestNoticeOfChangeServiceTest {
         updateCaseDetailsData(caseDetails, CHANGE_ORGANISATION_REQUEST_KEY, changeOrganisationRequest);
 
         given(jacksonUtils.convertValue(any(), any())).willReturn(changeOrganisationRequest);
-        given(dataStoreRepository.findCaseByCaseIdExternalApi(CASE_ID)).willReturn(caseDetails);
 
         RequestNoticeOfChangeResponse requestNoticeOfChangeResponse =
             service.requestNoticeOfChange(noCRequestDetails);
@@ -223,8 +222,6 @@ class RequestNoticeOfChangeServiceTest {
             .willReturn(organisationPolicies.get(0))
             .willReturn(organisationPolicies.get(1))
             .willReturn(organisationPolicies.get(2));
-
-        given(dataStoreRepository.findCaseByCaseIdExternalApi(CASE_ID)).willReturn(caseDetails);
 
         RequestNoticeOfChangeResponse requestNoticeOfChangeResponse
             = service.requestNoticeOfChange(noCRequestDetails);
@@ -269,8 +266,6 @@ class RequestNoticeOfChangeServiceTest {
             .willReturn(organisationPolicies.get(1))
             .willReturn(organisationPolicies.get(2))
             .willReturn(invokersOrganisationPolicy);
-
-        given(dataStoreRepository.findCaseByCaseIdExternalApi(CASE_ID)).willReturn(caseDetails);
     }
 
     @Test


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/ACA-147


### Change description ###
Update the assign access operation to use invoking user instead of the system user for fetching the case data. Previously a bug identified where the system user has been used with the caseworker-caa role, who had no access to the case data. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
