### PR TITLE
CCD-1236 - changed cache strategy

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -26,7 +26,7 @@ spring:
   cache:
     cache-names: userInfoCache,usersByOrganisationExternal,usersByOrganisationInternal,organisationAddressById,systemUserAccessTokenCache,caaAccessTokenCache,nocApproverAccessTokenCache,caseRoles,challengeQuestions
     caffeine:
-      spec: expireAfterAccess=1800s
+      spec: expireAfterWrite=1800s
   security:
     oauth2:
       client:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-1236

### Change description ###

Changed [cache strategy](https://www.javadoc.io/doc/com.github.ben-manes.caffeine/caffeine/2.2.2/com/github/benmanes/caffeine/cache/Caffeine.html#expireAfterWrite-long-java.util.concurrent.TimeUnit-) from `expireAfterAccess` to `expireAfterWrite` as static Idam system user tokens must expire always after certain period. 

```
[ ] Yes
[ x] No
```
