### PR TITLE
Ccd 1855 CVE 2021 22119

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,8 @@ plugins {
   id 'au.com.dius.pact' version '4.1.7'
 }
 
-ext['spring-security.version'] = '5.4.5'
+// Updated spring-security version to 5.4.7 to resolve CVE-2021-22119
+ext['spring-security.version'] = '5.4.7'
 ext['spring-framework.version'] = '5.3.7'
 
 group = 'uk.gov.hmcts.reform'
@@ -323,8 +324,9 @@ dependencies {
   implementation "com.nimbusds:nimbus-jose-jwt:7.9"
   implementation "net.minidev:json-smart:2.4.7"
 
-  implementation "org.springframework.security:spring-security-web:5.4.5"
-  implementation "org.springframework.security:spring-security-config:5.4.5"
+  // Updated spring-security components to version 5.4.7 to resolve CVE-2021-22119
+  implementation "org.springframework.security:spring-security-web:5.4.7"
+  implementation "org.springframework.security:spring-security-config:5.4.7"
   implementation "org.springframework.boot:spring-boot-starter-oauth2-client:2.4.5"
   implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server:2.4.5"
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -35,13 +35,6 @@
   </suppress>
 
   <suppress until="2021-09-25">
-    <notes>susceptible to a Denial-of-Service (DoS) attack via the initiation of the Authorization Request 
-      in an OAuth 2.0 Client Web and WebFlux application
-    </notes>
-    <cve>CVE-2021-22119</cve>
-  </suppress>
-
-  <suppress until="2021-09-25">
     <notes>In the Jakarta Expression Language implementation 3.0.3 and earlier, 
       a bug in the ELParserTokenManager enables invalid EL expressions to be evaluated as if they were valid.
     </notes>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-1855 (https://tools.hmcts.net/jira/browse/CCD-1855)


### Change description ###
- Updated spring-security version in build.gradle to 5.4.7 to resolve CVE-2021-22119


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
