### PR TITLE
CCD-1851: Resolve CVE-2021-28170

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -323,6 +323,9 @@ dependencies {
   implementation "com.nimbusds:nimbus-jose-jwt:7.9"
   implementation "net.minidev:json-smart:2.4.7"
 
+  // Explicitly specify version of jakarta.el to be used to resolve CVE-2021-28170
+  implementation group: 'org.glassfish', name: 'jakarta.el', version: '4.0.1'
+
   implementation "org.springframework.security:spring-security-web:5.4.5"
   implementation "org.springframework.security:spring-security-config:5.4.5"
   implementation "org.springframework.boot:spring-boot-starter-oauth2-client:2.4.5"

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -41,11 +41,4 @@
     <cve>CVE-2021-22119</cve>
   </suppress>
 
-  <suppress until="2021-09-25">
-    <notes>In the Jakarta Expression Language implementation 3.0.3 and earlier, 
-      a bug in the ELParserTokenManager enables invalid EL expressions to be evaluated as if they were valid.
-    </notes>
-    <cve>CVE-2021-28170</cve>
-  </suppress>
-
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -2,6 +2,17 @@
 <suppressions
   xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
 
+	<suppress>
+    <notes>
+			Declared as False positive on library com.nimbusds:lang-tag #3594 
+			https://github.com/jeremylong/DependencyCheck/issues/3594
+			CVE-2020-23171 Reference https://tools.hmcts.net/jira/browse/CCD-1869
+    </notes>
+    <packageUrl regex="true">^pkg:maven/com\.nimbusds/lang\-tag@.*$</packageUrl>
+    <cpe>cpe:/a:nim-lang:nim-lang</cpe>
+    <cve>CVE-2020-23171</cve>
+	</suppress>
+
   <suppress until="2021-09-25">
     <notes><![CDATA[
      It's a false positive - spring-security version is 5.3.x (see: https://pivotal.io/security/cve-2018-1258)
@@ -24,14 +35,6 @@
       https://github.com/jeremylong/DependencyCheck/issues/2866</notes>
     <cve>CVE-2007-1651</cve>
     <cve>CVE-2007-1652</cve>
-  </suppress>
-
-  <suppress until="2021-09-25">
-    <notes>A vulnerability in all versions of Nim-lang allows unauthenticated attackers to write files to 
-      arbitrary directories via a crafted zip file with dot-slash characters included in the name of the 
-      crafted file
-    </notes>
-    <cve>CVE-2020-23171</cve>
   </suppress>
 
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-1851 (https://tools.hmcts.net/jira/browse/CCD-1851)


### Change description ###
Changed build.gradle to explicitly specify version of jakarta.el to use.
This will resolve CVE-2021-28170.

Removed CVE-2021-28170 entry from suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
