### PR TITLE
CCD-2110: Address CVE-2021-42340

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -227,7 +227,7 @@ dependencyManagement {
       entry 'log4j-api'
     }
     // CVE-2021-25122
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.50') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.54') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -37,9 +37,4 @@
     <cve>CVE-2007-1652</cve>
   </suppress>
 
-  <suppress until="2021-11-25">
-    <notes>Suppress CVE affecting Tomcat temporarily until it can be addressed</notes>
-    <cve>CVE-2021-42340</cve>
-  </suppress>
-
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -37,4 +37,9 @@
     <cve>CVE-2007-1652</cve>
   </suppress>
 
+  <suppress until="2021-11-25">
+    <notes>Suppress CVE affecting spring-core temporarily until it can be addressed</notes>
+    <cve>CVE-2021-22096</cve>
+  </suppress>
+
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2110 (https://tools.hmcts.net/jira/browse/CCD-2110)


### Change description ###
- Updated dependencyManagement section of build.gradle. Set version of org.apache.tomcat.embed group to 9.0.54 to resolve CVE-2021-42340.
- Removed suppression of CVE-2021-42340 from suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
