### PR TITLE
CCD-2133: Address CVE-2021-22096

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ plugins {
 
 // Updated spring-security version to 5.4.7 to resolve CVE-2021-22119
 ext['spring-security.version'] = '5.4.7'
-ext['spring-framework.version'] = '5.3.7'
+ext['spring-framework.version'] = '5.3.12'
 
 group = 'uk.gov.hmcts.reform'
 version = '0.0.1'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -37,9 +37,4 @@
     <cve>CVE-2007-1652</cve>
   </suppress>
 
-  <suppress until="2021-11-25">
-    <notes>Suppress CVE affecting spring-core temporarily until it can be addressed</notes>
-    <cve>CVE-2021-22096</cve>
-  </suppress>
-
 </suppressions>

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -16,7 +16,7 @@
   <suppress until="2021-11-25">
     <notes><![CDATA[
      It's a false positive - spring-security version is 5.3.x (see: https://pivotal.io/security/cve-2018-1258)
-   ]]></notes>
+    ]]></notes>
     <cve>CVE-2018-1258</cve>
   </suppress>
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2133 (https://tools.hmcts.net/jira/browse/CCD-2133)


### Change description ###
- Updated build.gradle.  Set value of override of spring-framework.version property to 5.3.12 to address CVE-2021-22096.
- Removed temporary suppression of CVE-2021-22096 from suppressions.xml


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
