### PR TITLE
CCD-2351: Update log4j version to 2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 // Updated spring-security version to 5.4.7 to resolve CVE-2021-22119
 ext['spring-security.version'] = '5.4.7'
 ext['spring-framework.version'] = '5.3.12'
-ext['log4j2.version'] = '2.15.0'
+ext['log4j2.version'] = '2.16.0'
 
 group = 'uk.gov.hmcts.reform'
 version = '0.0.1'


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2351 (https://tools.hmcts.net/jira/browse/CCD-2351)


### Change description ###
Update log4j version to 2.16.0.  This release contains further mitigations for CVE-2021-44228 and also addresses CVE-2021-45046.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
