### PR TITLE
CCD-2543: Ignore Fortify scan results

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -426,6 +426,6 @@ task fortifyScan(type: JavaExec)  {
   main = "uk.gov.hmcts.fortifyclient.FortifyClientMainApp"
   classpath += sourceSets.test.runtimeClasspath
   jvmArgs = ['--add-opens=java.base/java.lang.reflect=ALL-UNNAMED']
-  // Uncomment the line below to prevent the build from failing if the Fortify scan detects issues
-  //ignoreExitValue = true
+  // The line below prevents the build from failing if the Fortify scan detects issues
+  ignoreExitValue = true
 }

--- a/config/fortify-client.properties
+++ b/config/fortify-client.properties
@@ -1,1 +1,1 @@
-fortify.client.releaseId=91394
+fortify.client.releaseId=98706


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-2543 (https://tools.hmcts.net/jira/browse/CCD-2543)


### Change description ###
Temporarily changed fortifyScan task in build.gradle so that it ignores the results of the scan.

Updated fortify-client.properties with new releaseId value.  New value is a result of moving project in Fortify to the CCD 2 application section.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
