### PR TITLE
CVE-2022-22968 : aac-manage-case-assignment fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 }
 
 ext['spring-security.version'] = '5.6.1'
-ext['spring-framework.version'] = '5.3.18'
+ext['spring-framework.version'] = '5.3.19'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.13.2'
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -36,9 +36,4 @@
     <cve>CVE-2007-1651</cve>
     <cve>CVE-2007-1652</cve>
   </suppress>
-
-  <suppress until="2022-05-25">
-    <cve>CVE-2022-22968</cve>
-  </suppress>
-
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-3092

### Change description ###

Upgrading framework to 5.3.19 due to this vulnerability:
In Spring Framework versions 5.3.0 - 5.3.18, 5.2.0 - 5.2.20, and older unsupported versions, the patterns for disallowedFields on a DataBinder are case sensitive which means a field is not effectively protected unless it is listed with both upper and lower case for the first character of the field, including upper and lower case for the first character of all nested fields within the property path.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
