### PR TITLE
CCD-3297: Added junit formatter to smoke and functional test tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,7 @@ task smoke(type: Test) {
       classpath += sourceSets.functionalTest.runtimeClasspath + sourceSets.main.output + sourceSets.test.output
       args = [
               '--plugin', "json:${cucumberReports.outputDir}/cucumber.json",
+              '--plugin', "junit:${buildDir}/test-results/smoke/cucumber.xml",
               '--tags', '@Smoke and not @Ignore',
               '--glue', 'uk.gov.hmcts.befta.player', 'src/functionalTest/resources/features'
       ]
@@ -131,6 +132,7 @@ task functional(type: Test) {
       args = [
               '--threads', '1',
               '--plugin', "json:${cucumberReports.outputDir}/cucumber.json",
+              '--plugin', "junit:${buildDir}/test-results/functional/cucumber.xml",
               '--tags', 'not @Ignore',
               '--glue', 'uk.gov.hmcts.befta.player', 'src/functionalTest/resources/features'
       ]


### PR DESCRIPTION
### JIRA link (if applicable) ###
CCD-3297 (https://tools.hmcts.net/jira/browse/CCD-3297)


### Change description ###
Added junit formatter plugin to doLast section of smoke and functional test tasks.  This causes test result XML files to be created in the locations expected by the smoke and functional stages of the pipeline.  These locations were recently corrected under DTSPO-6817.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
