### PR TITLE
CCD-3588 FTA patch

### DIFF
--- a/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/F-201 - Assign Access within Organisation.feature
+++ b/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/F-201 - Assign Access within Organisation.feature
@@ -134,7 +134,7 @@ Feature: F-201: Assign Access within Organisation
       And the response has all the details as expected,
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  @S-201.6a @Ignore
+  @S-201.6a
   Scenario: Must return an error response for an assignee user who doesn't have a solicitor role for the jurisdiction of the case
 
     Given a user [S1 - with a solicitor role under an organisation to assign a case role to another solicitor within the same organisation],
@@ -149,7 +149,7 @@ Feature: F-201: Assign Access within Organisation
       And the response has all the details as expected.
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  @S-201.6b @Ignore
+  @S-201.6b
   Scenario: Must return an error response for an assignee user who doesn't have a valid solicitor role for the jurisdiction of the case
 
     Given a user [S1 - with a solicitor role under an organisation to assign a case role to another solicitor within the same organisation],
@@ -164,7 +164,7 @@ Feature: F-201: Assign Access within Organisation
       And the response has all the details as expected.
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  @S-201.7 @Ignore
+  @S-201.7
   Scenario: Must return a negative response when the case doesn't contain an assignment for the invoker's organisation
 
     Given a user [S1 - a solicitor, to create a case under their organisation and share it with a fellow solicitor in the same organisation],

--- a/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/F-201 - Assign Access within Organisation.feature
+++ b/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/F-201 - Assign Access within Organisation.feature
@@ -7,7 +7,7 @@ Feature: F-201: Assign Access within Organisation
     Given an appropriate test context as detailed in the test data source
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  @S-201.1 @Ignore
+  @S-201.1
   Scenario: Solicitor successfully sharing case access with another solicitor in their org (happy path)
 
     Given a user [S1 - a solicitor, to create a case under their organisation and share it with a fellow solicitor in the same organisation],
@@ -25,7 +25,7 @@ Feature: F-201: Assign Access within Organisation
       And a call [by S2 to access the case created by S1] will get the expected response as in [F-201_Case_Found].
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  @S-201.1b @Ignore
+  @S-201.1b
   Scenario: Solicitor successfully sharing case access with another solicitor in their org (happy path) called with use_user_token to fetch case details
 
     Given a user [S1 - a solicitor, to create a case under their organisation and share it with a fellow solicitor in the same organisation],
@@ -45,7 +45,7 @@ Feature: F-201: Assign Access within Organisation
 
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  @S-201.2 @Ignore
+  @S-201.2
   Scenario: PUI CAA successfully sharing case access with another solicitor in their org (happy path)
 
     Given a user [S1 - a solicitor, to create a case under their organisation],
@@ -66,7 +66,7 @@ Feature: F-201: Assign Access within Organisation
 
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  @S-201.2b @Ignore
+  @S-201.2b
   Scenario: Must return an error response if PUI CAA tries to share a case access with another solicitor in their org called with use_user_token, but has no case access
 
     Given a user [S1 - a solicitor, to create a case under their organisation],
@@ -86,7 +86,7 @@ Feature: F-201: Assign Access within Organisation
       And a call [by S2 to access the case created by S1] will get the expected response as in [F-201_Case_Not_Found]
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-  @S-201.3 @Ignore
+  @S-201.3
   Scenario: Must return an error response if assignee doesn't exist in invoker's organisation
 
     Given a user [S1 - a solicitor, to create a case under their organisation and share it with a fellow solicitor in the same organisation],

--- a/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/F-201_S2_Querying_No_Access_Over_C1.td.json
+++ b/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/F-201_S2_Querying_No_Access_Over_C1.td.json
@@ -1,6 +1,6 @@
 {
 	"_guid_": "F-201_S2_Querying_No_Access_Over_C1",
-	"_extends_": "Case_Assigned_Users_Roles",
+	"_extends_": "Get_Case_Access__Base",
 	"title": "S2 Querying No Access Over C1",
 
 	"specs": [
@@ -14,7 +14,8 @@
 
 	"request": {
 		"queryParams": {
-			"case_ids": "${[scenarioContext][siblingContexts][F-201_Prerequisite_Case_Creation_C1][testData][actualResponse][body][id]}"
+			"case_ids": "${[scenarioContext][siblingContexts][F-201_Prerequisite_Case_Creation_C1][testData][actualResponse][body][id]}",
+			"user_ids": "${[scenarioContext][testData][users][invokingUser][id]}"
 		}
 	},
 

--- a/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/F-201_S2_Querying_No_Access_Over_C1.td.json
+++ b/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/F-201_S2_Querying_No_Access_Over_C1.td.json
@@ -13,9 +13,13 @@
 	},
 
 	"request": {
-		"queryParams": {
-			"case_ids": "${[scenarioContext][siblingContexts][F-201_Prerequisite_Case_Creation_C1][testData][actualResponse][body][id]}",
-			"user_ids": "${[scenarioContext][testData][users][invokingUser][id]}"
+		"body": {
+			"case_ids": [
+				"${[scenarioContext][siblingContexts][F-201_Prerequisite_Case_Creation_C1][testData][actualResponse][body][id]}"
+			],
+			"user_ids": [
+				"${[scenarioContext][testData][users][invokingUser][id]}"
+			]
 		}
 	},
 

--- a/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/F-201_S2_Querying_Their_Access_Over_C1.td.json
+++ b/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/F-201_S2_Querying_Their_Access_Over_C1.td.json
@@ -13,9 +13,13 @@
 	},
 
 	"request": {
-		"queryParams": {
-			"case_ids": "${[scenarioContext][siblingContexts][F-201_Prerequisite_Case_Creation_C1][testData][actualResponse][body][id]}",
-			"user_ids": "${[scenarioContext][testData][users][invokingUser][id]}"
+		"body": {
+			"case_ids": [
+				"${[scenarioContext][siblingContexts][F-201_Prerequisite_Case_Creation_C1][testData][actualResponse][body][id]}"
+			],
+			"user_ids": [
+				"${[scenarioContext][testData][users][invokingUser][id]}"
+			]
 		}
 	},
 

--- a/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/F-201_S2_Querying_Their_Access_Over_C1.td.json
+++ b/src/functionalTest/resources/features/F-201 - Assign Access within Organisation/F-201_S2_Querying_Their_Access_Over_C1.td.json
@@ -1,6 +1,6 @@
 {
 	"_guid_": "F-201_S2_Querying_Their_Access_Over_C1",
-	"_extends_": "Case_Assigned_Users_Roles",
+	"_extends_": "Get_Case_Access__Base",
 	"title": "S2 Querying Their Access Over C1",
 
 	"specs": [
@@ -14,7 +14,8 @@
 
 	"request": {
 		"queryParams": {
-			"case_ids": "${[scenarioContext][siblingContexts][F-201_Prerequisite_Case_Creation_C1][testData][actualResponse][body][id]}"
+			"case_ids": "${[scenarioContext][siblingContexts][F-201_Prerequisite_Case_Creation_C1][testData][actualResponse][body][id]}",
+			"user_ids": "${[scenarioContext][testData][users][invokingUser][id]}"
 		}
 	},
 

--- a/src/functionalTest/resources/features/F-202 - Get Assignments in My Organisation/F-202 - Get Assignments in My Organisation.feature
+++ b/src/functionalTest/resources/features/F-202 - Get Assignments in My Organisation/F-202 - Get Assignments in My Organisation.feature
@@ -8,7 +8,7 @@ Background:
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # ACA-48 / AC-1
-@S-202.1 @Ignore
+@S-202.1
 Scenario: Must return case assignments in my organisation for the provided Case IDs
 
     Given a user [Becky – a solicitor with the required permissions to create a case],
@@ -30,7 +30,7 @@ Scenario: Must return case assignments in my organisation for the provided Case 
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # ACA-48 / AC-2
-@S-202.2 @Ignore
+@S-202.2
 Scenario: Must return an error response when a malformed case ID is provided
 
     Given a user [Becky – a solicitor with the required permissions to create a case],
@@ -66,7 +66,7 @@ Scenario: Must return an error response for a missing case ID
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # ACA-48 / AC-4
-@S-202.4 @Ignore
+@S-202.4
 Scenario: Must return an error response for a malformed Case ID List
 
     Given a user [Becky – a solicitor with the required permissions to create a case],

--- a/src/functionalTest/resources/features/F-203 - Unassign Access Within Organisation/F-203 - Unassign Access Within Organisation.feature
+++ b/src/functionalTest/resources/features/F-203 - Unassign Access Within Organisation/F-203 - Unassign Access Within Organisation.feature
@@ -1,5 +1,5 @@
 #=================================================
-@F-203 @Ignore
+@F-203
 Feature: F-203: Unassign Access Within Organisation
 #=================================================
 
@@ -130,9 +130,10 @@ Feature: F-203: Unassign Access Within Organisation
       And a call [by Becky to access the case C1] will get the expected response as in [F-203_C1_Case_Not_Found_Becky],
       And a call [by Becky to access the case C2] will get the expected response as in [F-203_C2_Case_Not_Found_Becky],
       And a call [by Becky to access the case C3] will get the expected response as in [F-203_C3_Case_Not_Found_Becky].
+
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # ACA-51 A/C 5
-  @S-203.5 @Ignore
+  @S-203.5
   Scenario: Must return an error response if intended unassignee doesn't exist in invoker's organisation
 
     Given a user [Becky - with a Solicitor role for a particular jurisdiction under an organisation to create, assign and unassign access to a case for another solicitor in their organisation - O1],
@@ -153,7 +154,7 @@ Feature: F-203: Unassign Access Within Organisation
       And a call [by Benjamin to access the case C1 with separate organisation policies] will get the expected response as in [F-203_Separate_Org_Policies_Case_Found_Benjamin].
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # ACA-51 A/C 6
-  @S-203.6 @Ignore
+  @S-203.6
   Scenario: Must return an error response for a malformed Case ID
 
     Given a user [Becky - with a Solicitor role for a particular jurisdiction under an organisation to create, assign and unassign access to a case for another solicitor in their organisation],
@@ -174,7 +175,7 @@ Feature: F-203: Unassign Access Within Organisation
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # ACA-51 A/C 7
-  @S-203.7 @Ignore
+  @S-203.7
   Scenario: Must return an error response for a missing Case ID
 
     Given a user [Becky - with a Solicitor role for a particular jurisdiction under an organisation to create, assign and unassign access to a case for another solicitor in their organisation],
@@ -195,7 +196,7 @@ Feature: F-203: Unassign Access Within Organisation
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # ACA-51 A/C 8
-  @S-203.8 @Ignore
+  @S-203.8
   Scenario: Must return an error response for a malformed Case-Role
 
     Given a user [Becky - with a Solicitor role for a particular jurisdiction under an organisation to create, assign and unassign access to a case for another solicitor in their organisation],
@@ -216,7 +217,7 @@ Feature: F-203: Unassign Access Within Organisation
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # ACA-51 A/C 9 (Happy path)
-  @S-203.9 @Ignore
+  @S-203.9
   Scenario: Solicitor successfully removing access to multiple cases for multiple solicitors in their org with respect to a specific case role (happy path)
 
     Given a user [Becky - with a Solicitor role in a jurisdiction under an organisation to assign and Unassign a case role to a solicitor within the same organisation],
@@ -255,7 +256,7 @@ Feature: F-203: Unassign Access Within Organisation
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # ACA-51 A/C 10 (Happy path)
-  @S-203.10 @Ignore
+  @S-203.10
   Scenario: Pui-CAA successfully removing access to multiple cases for multiple solicitors in their org with respect to a specific case role (happy path)
 
     Given a user [Becky - with a Solicitor role in a jurisdiction under an organisation to assign and Unassign a case role to a solicitor within the same organisation],
@@ -294,7 +295,7 @@ Feature: F-203: Unassign Access Within Organisation
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # ACA-51 A/C 11
-  @S-203.11 @Ignore
+  @S-203.11
   Scenario: Must return an error response for a missing Assignee ID
 
     Given a user [Becky - with a Solicitor role for a particular jurisdiction under an organisation to create, assign and unassign access to a case for another solicitor in their organisation],

--- a/src/functionalTest/resources/features/F-203 - Unassign Access Within Organisation/F-203 - Unassign Access Within Organisation.feature
+++ b/src/functionalTest/resources/features/F-203 - Unassign Access Within Organisation/F-203 - Unassign Access Within Organisation.feature
@@ -8,7 +8,7 @@ Feature: F-203: Unassign Access Within Organisation
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # ACA-51 A/C 1
-  @S-203.1 @Ignore
+  @S-203.1
   Scenario: Solicitor successfully removing case access for another solicitor in their org (happy path)
 
     Given a user [Becky - with a Solicitor role for a particular jurisdiction under an organisation to create, assign and unassign access to a case for another solicitor in their organisation],
@@ -33,7 +33,7 @@ Feature: F-203: Unassign Access Within Organisation
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # ACA-51 A/C 2
-  @S-203.2 @Ignore
+  @S-203.2
   Scenario: CAA successfully removing case access for another solicitor in their org (happy path)
 
     Given a user [Becky - with a solicitor role in a particular jurisdiction within an organisation, to create a case],
@@ -58,7 +58,7 @@ Feature: F-203: Unassign Access Within Organisation
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # ACA-51 A/C 3
-  @S-203.3 @Ignore
+  @S-203.3
   Scenario: Solicitor successfully removing access to multiple cases for multiple solicitors in their org (happy path)
 
     Given a user [Becky - with a Solicitor role in a jurisdiction under an organisation to assign and Unassign a case role to a solicitor within the same organisation],
@@ -97,7 +97,7 @@ Feature: F-203: Unassign Access Within Organisation
 
 #-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 # ACA-51 A/C 4
-  @S-203.4 @Ignore
+  @S-203.4
   Scenario: Pui-caa successfully removing access to multiple cases for multiple solicitors in their org (happy path)
 
     Given a user [Becky - with a solicitor role in a particular jurisdiction within an organisation, to create a case],

--- a/src/functionalTest/resources/features/F-209 - Apply NoC Decision/AccessAssignment/F-209.6_Delete_Creator_Role.td.json
+++ b/src/functionalTest/resources/features/F-209 - Apply NoC Decision/AccessAssignment/F-209.6_Delete_Creator_Role.td.json
@@ -1,12 +1,8 @@
 {
   "_guid_": "F-209.6_Delete_Creator_Role",
-  "title": "Assign Access to Case",
+  "_extends_": "Delete_Case_Access__Base",
+  "title": "Remove Access to Case",
 
-  "productName": "Manage Case Assignment Microservice",
-  "operationName": "Assign Access within Organisation",
-
-  "method": "DELETE",
-  "uri": "{{CCD_DATA_STORE_API_BASE_URL}}/case-users",
 
   "s2sClientId": "aac_manage_case_assignment",
   "userTokenClientId": "xuiwebapp",
@@ -35,14 +31,6 @@
           "user_id": "${[scenarioContext][testData][users][S1][id]}"
         }
       ]
-    }
-  },
-
-  "expectedResponse": {
-    "_extends_" : "Common_Response",
-    "responseCode": 200,
-    "body": {
-      "status_message" : "Case-User-Role assignments removed successfully"
     }
   }
 }

--- a/src/functionalTest/resources/features/F-209 - Apply NoC Decision/AccessAssignment/F-209_Assign_Access_Base.td.json
+++ b/src/functionalTest/resources/features/F-209 - Apply NoC Decision/AccessAssignment/F-209_Assign_Access_Base.td.json
@@ -1,38 +1,16 @@
 {
   "_guid_": "F-209_Assign_Access_Base",
+  "_extends_": "Assign_Case_Access__Base",
   "title": "Assign Access to Case",
 
-  "productName": "Manage Case Assignment Microservice",
-  "operationName": "Assign Access within Organisation",
-
-  "method": "POST",
-  "uri": "{{CCD_DATA_STORE_API_BASE_URL}}/case-users",
-
+  
   "s2sClientId": "aac_manage_case_assignment",
   "userTokenClientId": "xuiwebapp",
 
 
-  "specs": [
-    "to assign access for Richard to the previously created case",
-    "to assign users to the case"
-  ],
-
   "users": {
     "invokingUser": {
       "_extends_": "ACA_Users_Caseworker_CAA"
-    }
-  },
-
-  "request": {
-    "_extends_": "Common_Request"
-
-  },
-
-  "expectedResponse": {
-    "_extends_" : "Common_Response",
-    "responseCode": 201,
-    "body": {
-      "status_message" : "Case-User-Role assignments created successfully"
     }
   }
 }

--- a/src/functionalTest/resources/features/F-209 - Apply NoC Decision/AccessAssignment/F-209_Delete_Creator_Role.td.json
+++ b/src/functionalTest/resources/features/F-209 - Apply NoC Decision/AccessAssignment/F-209_Delete_Creator_Role.td.json
@@ -1,12 +1,8 @@
 {
   "_guid_": "F-209_Delete_Creator_Role",
-  "title": "Assign Access to Case",
+  "_extends_": "Delete_Case_Access__Base",
+  "title": "Remove Access to Case",
 
-  "productName": "Manage Case Assignment Microservice",
-  "operationName": "Assign Access within Organisation",
-
-  "method": "DELETE",
-  "uri": "{{CCD_DATA_STORE_API_BASE_URL}}/case-users",
 
   "s2sClientId": "aac_manage_case_assignment",
   "userTokenClientId": "xuiwebapp",
@@ -26,7 +22,6 @@
   },
 
   "request": {
-    "_extends_": "Common_Request",
     "body": {
       "case_users": [
         {
@@ -35,14 +30,6 @@
           "user_id": "${[scenarioContext][testData][users][S1][id]}"
         }
       ]
-    }
-  },
-
-  "expectedResponse": {
-    "_extends_" : "Common_Response",
-    "responseCode": 200,
-    "body": {
-      "status_message" : "Case-User-Role assignments removed successfully"
     }
   }
 }

--- a/src/functionalTest/resources/features/F-209 - Apply NoC Decision/AccessAssignment/F-209_GET_Case_Access_Base.td.json
+++ b/src/functionalTest/resources/features/F-209 - Apply NoC Decision/AccessAssignment/F-209_GET_Case_Access_Base.td.json
@@ -15,8 +15,10 @@
   },
 
   "request": {
-    "queryParams" : {
-      "case_ids" : "${[scenarioContext][ParentContext][childContexts][F-209_NoC_Case_Creation_By_Richard_With_Assigned_Org_Policies][testData][actualResponse][body][id]}"
+    "body" : {
+      "case_ids": [
+        "${[scenarioContext][ParentContext][childContexts][F-209_NoC_Case_Creation_By_Richard_With_Assigned_Org_Policies][testData][actualResponse][body][id]}"
+      ]
     }
   },
 

--- a/src/functionalTest/resources/features/F-209 - Apply NoC Decision/AccessAssignment/F-209_GET_Case_Access_Base.td.json
+++ b/src/functionalTest/resources/features/F-209 - Apply NoC Decision/AccessAssignment/F-209_GET_Case_Access_Base.td.json
@@ -1,24 +1,12 @@
 {
   "_guid_": "F_209_get_case_users_base",
-  "title": "Assign Access to Case",
+  "_extends_": "Get_Case_Access__Base",
+  "title": "Verify Access to Case",
 
-  "productName": "Manage Case Assignment Microservice",
-  "operationName": "Assign Access within Organisation",
-
-  "method": "GET",
-  "uri": "{{CCD_DATA_STORE_API_BASE_URL}}/case-users",
 
   "s2sClientId": "aac_manage_case_assignment",
   "userTokenClientId": "xuiwebapp",
 
-  "specs": [
-    "to assign access for Richard to the previously created case",
-    "to assign users to the case",
-    "to verify that Richard and anyone else in Richard's organisation has had their access removed",
-    "to verify that Richard still has access to the case - C1",
-    "to verify that Richard still has access to the case and Dil does not have access - C1",
-    "to verify that Richard And anyone else in Richard's organisation have not had their access removed"
-  ],
 
   "users": {
     "invokingUser": {
@@ -27,15 +15,12 @@
   },
 
   "request": {
-    "_extends_": "Common_Request",
     "queryParams" : {
       "case_ids" : "${[scenarioContext][ParentContext][childContexts][F-209_NoC_Case_Creation_By_Richard_With_Assigned_Org_Policies][testData][actualResponse][body][id]}"
     }
   },
 
   "expectedResponse": {
-    "_extends_" : "Common_Response",
-    "responseCode": 200,
     "body": {
       "case_users" : [ ]
     }

--- a/src/functionalTest/resources/features/F-209 - Apply NoC Decision/AccessAssignment/F-209_GET_Case_Access_Richard_Assigned.td.json
+++ b/src/functionalTest/resources/features/F-209 - Apply NoC Decision/AccessAssignment/F-209_GET_Case_Access_Richard_Assigned.td.json
@@ -2,6 +2,13 @@
   "_guid_": "F_209_get_case_users_richard_assigned",
   "_extends_": "F_209_get_case_users_base",
 
+
+  "specs": [
+    "to verify that Richard And anyone else in Richard's organisation have not had their access removed",
+    "to verify that Richard still has access to the case and Dil does not have access - C1"
+  ],
+
+
   "request": {
     "_extends_": "Common_Request",
     "queryParams" : {

--- a/src/functionalTest/resources/features/F-209 - Apply NoC Decision/AccessAssignment/F-209_GET_Case_Access_Richard_NOT_Assigned.td.json
+++ b/src/functionalTest/resources/features/F-209 - Apply NoC Decision/AccessAssignment/F-209_GET_Case_Access_Richard_NOT_Assigned.td.json
@@ -3,6 +3,9 @@
   "_extends_": "F_209_get_case_users_base",
 
 
+  "specs": [
+    "to verify that Richard and anyone else in Richard's organisation has had their access removed"
+  ],
 
 
   "request": {

--- a/src/functionalTest/resources/features/common/data-store/AccessAssignment/Assign_Case_Access__Base.td.json
+++ b/src/functionalTest/resources/features/common/data-store/AccessAssignment/Assign_Case_Access__Base.td.json
@@ -1,0 +1,20 @@
+{
+	"_guid_": "Assign_Case_Access__Base",
+
+	"productName": "CCD Data Store",
+	"operationName": "Add Case-Assigned Users and Roles",
+
+	"method": "POST",
+	"uri": "{{CCD_DATA_STORE_API_BASE_URL}}/case-users",
+
+	"request": {
+		"_extends_": "Common_Request"
+	},
+
+	"expectedResponse": {
+		"_extends_" : "Common_201_Response",
+		"body": {
+			"status_message" : "Case-User-Role assignments created successfully"
+		}
+	}
+}

--- a/src/functionalTest/resources/features/common/data-store/AccessAssignment/Delete_Case_Access__Base.td.json
+++ b/src/functionalTest/resources/features/common/data-store/AccessAssignment/Delete_Case_Access__Base.td.json
@@ -1,0 +1,23 @@
+{
+	"_guid_": "Delete_Case_Access__Base",
+
+	"productName": "CCD Data Store",
+	"operationName": "Remove Case-Assigned Users and Roles",
+
+	"method": "DELETE",
+	"uri": "{{CCD_DATA_STORE_API_BASE_URL}}/case-users",
+
+	"request": {
+		"_extends_": "Common_Request",
+		"body": {
+			"case_users": []
+		}
+	},
+
+	"expectedResponse": {
+		"_extends_" : "Common_200_Response",
+		"body": {
+			"status_message" : "Case-User-Role assignments removed successfully"
+		}
+	}
+}

--- a/src/functionalTest/resources/features/common/data-store/AccessAssignment/Get_Case_Access__Base.td.json
+++ b/src/functionalTest/resources/features/common/data-store/AccessAssignment/Get_Case_Access__Base.td.json
@@ -4,11 +4,15 @@
 	"productName": "CCD Data Store",
 	"operationName": "Get Case-Assigned Users and Roles",
 
-	"method": "GET",
-	"uri": "{{CCD_DATA_STORE_API_BASE_URL}}/case-users",
+	"method": "POST",
+	"uri": "{{CCD_DATA_STORE_API_BASE_URL}}/case-users/search",
 
 	"request": {
-		"_extends_": "Common_Request"
+		"_extends_": "Common_Request",
+		"body": {
+			"case_ids": [],
+			"user_ids": []
+		}
 	},
 
 	"expectedResponse": {

--- a/src/functionalTest/resources/features/common/data-store/AccessAssignment/Get_Case_Access__Base.td.json
+++ b/src/functionalTest/resources/features/common/data-store/AccessAssignment/Get_Case_Access__Base.td.json
@@ -1,5 +1,5 @@
 {
-	"_guid_": "Case_Assigned_Users_Roles",
+	"_guid_": "Get_Case_Access__Base",
 
 	"productName": "CCD Data Store",
 	"operationName": "Get Case-Assigned Users and Roles",
@@ -8,10 +8,7 @@
 	"uri": "{{CCD_DATA_STORE_API_BASE_URL}}/case-users",
 
 	"request": {
-		"_extends_": "Common_Request",
-		"queryParams": {
-			"user_ids": "${[scenarioContext][testData][users][invokingUser][id]}"
-		}
+		"_extends_": "Common_Request"
 	},
 
 	"expectedResponse": {

--- a/src/functionalTest/resources/features/common/data-store/Prerequisite_Case_Creation_C0_Without_Org_Policies.td.json
+++ b/src/functionalTest/resources/features/common/data-store/Prerequisite_Case_Creation_C0_Without_Org_Policies.td.json
@@ -45,7 +45,8 @@
 				},
 				"OrganisationPolicyField2": {
 					"OrgPolicyCaseAssignedRole": "[Defendant]"
-				}
+				},
+				"SearchCriteria" : {}
 			},
 			"security_classifications": {
 				"OrganisationPolicyField2": {
@@ -59,6 +60,10 @@
 					"value": {
 						"OrgPolicyCaseAssignedRole": "PUBLIC"
 					}
+				},
+				"SearchCriteria" : {
+					"classification" : "PUBLIC",
+					"value" : { }
 				}
 			},
 			"data_classification": {
@@ -73,6 +78,10 @@
 					"value": {
 						"OrgPolicyCaseAssignedRole": "PUBLIC"
 					}
+				},
+				"SearchCriteria" : {
+					"classification" : "PUBLIC",
+					"value" : { }
 				}
 			}
 		}

--- a/src/functionalTest/resources/features/common/response/Case_Found.td.json
+++ b/src/functionalTest/resources/features/common/response/Case_Found.td.json
@@ -62,7 +62,8 @@
             "id": "[[ANYTHING_PRESENT]]",
             "value": "value in collection element - 2"
           }
-        ]
+        ],
+        "SearchCriteria" : {}
       },
       "data_classification": {
         "AddressField": {
@@ -138,6 +139,10 @@
             }
           ],
           "classification": "PUBLIC"
+        },
+        "SearchCriteria" : {
+          "classification" : "PUBLIC",
+          "value" : { }
         }
       }
     }

--- a/src/functionalTest/resources/features/common/response/Case_Not_Found.td.json
+++ b/src/functionalTest/resources/features/common/response/Case_Not_Found.td.json
@@ -17,8 +17,8 @@
   "expectedResponse": {
     "_extends_" : "Common_404_Response",
     "body" : {
-      "exception" : "uk.gov.hmcts.ccd.endpoint.exceptions.ResourceNotFoundException",
-      "message" : "No case found",
+      "exception" : "uk.gov.hmcts.ccd.domain.service.getcase.CaseNotFoundException",
+      "message" : "No case found for reference: ${[scenarioContext][testData][request][pathVariables][caseId]}",
       "details" : null,
       "callbackErrors" : null,
       "callbackWarnings" : null


### PR DESCRIPTION
### JIRA link (if applicable) ###

[CCD-3588](https://tools.hmcts.net/jira/browse/CCD-3588) _"AAC API in production failing-returns 502 for sols who are attempting to share a case in exui"_

### Change description ###

Reenable the FTAs that are dissabled due to:
* missing the SearchCriteria property introduced for GlobalSearch.
* after 404 response change from data-stores get-case API.

> NB: this PR is based off #425 and is dependent on hmcts/ccd-data-store-api#2064

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
