### PR TITLE
CCD-3426 CVE-2022-34305 tomcat upgrade 9.0.65, suppression removed

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -231,7 +231,7 @@ dependencyManagement {
     }
 
     // CVE-2021-23181
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.63') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.65') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -7,14 +7,12 @@
     <notes>False Positives
       CVE-2018-1258 refer https://tools.hmcts.net/jira/browse/CCD-645
       CVE-2016-1000027 refer https://tools.hmcts.net/jira/browse/CCD-3246
-      CVE-2022-34305 refer https://tools.hmcts.net/jira/browse/CCD-3426
       CVE-2022-22978 refer https://tools.hmcts.net/jira/browse/CCD-3513 Java Upgrade
       CVE-2021-22112 refer https://tools.hmcts.net/jira/browse/CCD-3514 Java Upgrade
       CVE-2022-22976 refer https://tools.hmcts.net/jira/browse/CCD-3515 Java Upgrade
     </notes>
     <cve>CVE-2018-1258</cve>
     <cve>CVE-2016-1000027</cve>
-    <cve>CVE-2022-34305</cve>
     <cve>CVE-2022-22978</cve>
     <cve>CVE-2021-22112</cve>
     <cve>CVE-2022-22976</cve>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-3426
CVE-2022-34305 tomcat upgrade 9.0.65

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
