### PR TITLE
CCD-4035 PATCH to existing PR #455

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -16,7 +16,7 @@ GradleBuilder builder = new GradleBuilder(this, product)
 def definitionStoreDevelopPr = "PR-1174"  // This doesn't change frequently, but when it does, only change this value.
 def dataStoreApiDevelopPr    = "PR-2163" // This doesn't change frequently, but when it does, only change this value.
 def prsToUseAat              = "PR-148,PR-161,PR-167,PR-259,PR-264" // Set this value to a PR number, or add it as a comma-separated value, if it's to follow CI/CD.
-def prsRunningInIsolation    = "PR-455" // Set this value to a PR number, or add it as a comma-separated value, if PRs for MCA, Data-Store and Def-Store are all configured to run in isolation from other PRs.
+def prsRunningInIsolation    = "PR-455,PR-463" // Set this value to a PR number, or add it as a comma-separated value, if PRs for MCA, Data-Store and Def-Store are all configured to run in isolation from other PRs.
 
 def secrets = [
   'rpx-${env}': [

--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,7 @@ task smoke(type: Test) {
     generateCucumberReports.enabled = true
     cucumberReports.outputDir = file("${project.buildDir}/reports/tests/befta/smoke")
     cucumberReports.reports = files("${cucumberReports.outputDir}/cucumber.json")
+    cucumberReports.notFailingStatuses = ["skipped", "passed"]
 
     javaexec {
       main = "uk.gov.hmcts.reform.managecase.befta.ManageCaseAssignmentBeftaMain"
@@ -103,7 +104,8 @@ task smoke(type: Test) {
               '--plugin', "json:${cucumberReports.outputDir}/cucumber.json",
               '--plugin', "junit:${buildDir}/test-results/smoke/cucumber.xml",
               '--tags', '@Smoke and not @Ignore',
-              '--glue', 'uk.gov.hmcts.befta.player', 'src/functionalTest/resources/features'
+              '--glue', 'uk.gov.hmcts.befta.player', 
+              '--glue', 'uk.gov.hmcts.reform.managecase.befta', 'src/functionalTest/resources/features'
       ]
       // '--add-opens=...' added to suppress 'WARNING: An illegal reflective access operation has occurred' in uk.gov.hmcts.befta.util.CucumberStepAnnotationUtils
       jvmArgs = [ '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED' ]
@@ -125,6 +127,7 @@ task functional(type: Test) {
     generateCucumberReports.enabled = true
     cucumberReports.outputDir = file("${project.buildDir}/reports/tests/befta/functional")
     cucumberReports.reports = files("${cucumberReports.outputDir}/cucumber.json")
+    cucumberReports.notFailingStatuses = ["skipped", "passed"]
 
     javaexec {
       main = "uk.gov.hmcts.reform.managecase.befta.ManageCaseAssignmentBeftaMain"
@@ -134,7 +137,8 @@ task functional(type: Test) {
               '--plugin', "json:${cucumberReports.outputDir}/cucumber.json",
               '--plugin', "junit:${buildDir}/test-results/functional/cucumber.xml",
               '--tags', 'not @Ignore',
-              '--glue', 'uk.gov.hmcts.befta.player', 'src/functionalTest/resources/features'
+              '--glue', 'uk.gov.hmcts.befta.player',
+              '--glue', 'uk.gov.hmcts.reform.managecase.befta', 'src/functionalTest/resources/features'
       ]
       // '--add-opens=...' added to suppress 'WARNING: An illegal reflective access operation has occurred' in uk.gov.hmcts.befta.util.CucumberStepAnnotationUtils
       jvmArgs = [ '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED' ]

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,8 +15,12 @@
   <suppress>
     <notes>Temporary Suppression
         CVE-2021-37533 refer [Ticket]
-        CVE-2021-4277 refer [Ticket]</notes>
+        CVE-2021-4277 refer [Ticket]
+        CVE-2022-3064 refer [Ticket]
+        CVE-2021-4235 refer [Ticket]</notes>
     <cve>CVE-2021-37533</cve>
     <cve>CVE-2021-4277</cve>
+    <cve>CVE-2022-3064</cve>
+    <cve>CVE-2021-4235</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###

   [CCD-4035](https://tools.hmcts.net/jira/browse/CCD-4035) _"Expand aac-manage-case-assigment FTs to cover new CreatedBy field"_

### Change description ###

This is a patch to #455.

* Adjust cucumber configuration in `build.gradle` to allow optional skip of `@callbackTests` without failing tests.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
