### PR TITLE
CCD-4283: Bump gradle-java-plugin to 0.12.40

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.10.RELEASE'
   id 'org.springframework.boot' version '2.6.10'
-  id 'uk.gov.hmcts.java' version '0.12.37'
+  id 'uk.gov.hmcts.java' version '0.12.40'
   id 'com.github.ben-manes.versions' version '0.28.0'
   id 'com.github.spacialcircumstances.gradle-cucumber-reporting' version '0.1.23'
   id 'org.sonarqube' version '2.8'


### PR DESCRIPTION
### JIRA link ###
https://tools.hmcts.net/jira/browse/CCD-4283

### Change description ###
Bump gradle-java-plugin to 0.12.40

**Does this PR introduce a breaking change?**
```
[ ] Yes
[x] No
```