### PR TITLE
CCD-4398 Upgrade dependencies to resolve CVE-2023-24998 #1354

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -236,7 +236,7 @@ dependencyManagement {
     }
 
     // CVE-2021-23181
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.69') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.73') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'
@@ -300,6 +300,7 @@ dependencies {
   implementation group: 'com.vladmihalcea', name: 'hibernate-types-52', version: '2.9.13'
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign', version: '3.1.3'
 
+  implementation group: 'commons-fileupload', name: 'commons-fileupload', version: '1.5'
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.7'
   implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
   implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-bootstrap', version: '3.0.1'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
-        CVE-2022-45688 refer [Ticket]
-        CVE-2023-24998 refer [Ticket]</notes>
+        CVE-2022-45688 refer [Ticket]</notes>
     <cve>CVE-2022-45688</cve>
-    <cve>CVE-2023-24998</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/CCD-4398


### Change description ###
Upgrade tomcat and commons-fileupload  to resolve CVE-2023-24998

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
