### PR TITLE
Clean up old MI from code

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -130,11 +130,6 @@ withPipeline("java", product, component) {
   onPR {
     enableSlackNotifications('#ccd-pr-builds')
     enablePactAs([AppPipelineDsl.PactRoles.PROVIDER])
-
-    def githubApi = new GithubAPI(this)
-    if (!githubApi.getLabelsbyPattern(env.BRANCH_NAME, "keep-helm")) {
-      enableCleanupOfHelmReleaseOnSuccess()
-    }
   }
 
   // Check if the build should be wired to an environment higher than 'preview'.

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 plugins {
   id 'application'
   id 'jacoco'
-  id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+  id 'io.spring.dependency-management' version '1.0.11.RELEASE'
   id 'org.springframework.boot' version '2.6.10'
   id 'uk.gov.hmcts.java' version '0.12.43'
   id 'com.github.ben-manes.versions' version '0.28.0'

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -1,1 +1,0 @@
-managed_identity_object_id = "9b21b394-7b4c-452f-accc-d51b806cd8d7"

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,1 +1,0 @@
-managed_identity_object_id = "de008641-d003-4a8d-a50b-5a43dc98f23f"

--- a/infrastructure/ithc.tfvars
+++ b/infrastructure/ithc.tfvars
@@ -1,1 +1,0 @@
-managed_identity_object_id = "3c0fd81a-bf92-48b3-87d3-000604f36fda"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -20,7 +20,6 @@ module "key-vault" {
   # dcd_cc-dev group object ID
   product_group_object_id    = "38f9dea6-e861-4a50-9e73-21e64f563537"
   common_tags                = "${var.common_tags}"
-  managed_identity_object_id = "${var.managed_identity_object_id}"
   create_managed_identity    = true
 }
 

--- a/infrastructure/perftest.tfvars
+++ b/infrastructure/perftest.tfvars
@@ -1,1 +1,0 @@
-managed_identity_object_id = "d7a091ff-9c94-440d-9468-98381928fad8"

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,1 +1,0 @@
-managed_identity_object_id = "6252924e-e979-4bba-83be-73d996e482b1"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -24,7 +24,3 @@ variable "tenant_id" {
 variable "jenkins_AAD_objectId" {
   description = "(Required) The Azure AD object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies."
 }
-
-variable "managed_identity_object_id" {
-  default = ""
-}


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-15408

Removes old identity from code after  https://github.com/hmcts/aac-manage-case-assignment/pull/497
tfvars files just removed as they only contained these MI references


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
