### PR TITLE
Revert move to Caffeine caching

### DIFF
--- a/src/functionalTest/resources/features/F-200/S-200.1.td.json
+++ b/src/functionalTest/resources/features/F-200/S-200.1.td.json
@@ -40,6 +40,16 @@
 		"body": {
 			"status": "UP",
 			"components": {
+				"discoveryComposite": {
+					"description": "Discovery Client not initialized",
+					"status": "UNKNOWN",
+					"components": {
+						"discoveryClient": {
+							"description": "Discovery Client not initialized",
+							"status": "UNKNOWN"
+						}
+					}
+				},
 				"diskSpace": {
 					"status": "UP",
 					"details": {

--- a/src/integrationTest/resources/integration-test.properties
+++ b/src/integrationTest/resources/integration-test.properties
@@ -10,4 +10,3 @@ zuul.routes.definition-store.url=http://localhost:${wiremock.server.port:4451}
 prd.host=http://localhost:${wiremock.server.port:8090}
 spring.cache.type=none
 ccd.s2s-authorised.services.case_user_roles=aac_manage_case_assignment
-spring.cloud.discovery.client.composite-indicator.enabled=false

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -44,11 +44,6 @@ spring:
           oidc:
             client-id: internal
             client-secret: internal
-  cloud:
-    discovery:
-      client:
-        composite-indicator:
-          enabled: false
 idam:
   api:
     url: ${IDAM_API_URL:http://localhost:5000}


### PR DESCRIPTION
"CCD-4214 Remove discoveryComposite from health endpoint (#473)"

This reverts commit 86d24b6aa517aad5491be1d88949bb850e5b8160.

https://tools.hmcts.net/jira/browse/CCD-4214


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X] No
```
