### PR TITLE
DTSPO-15909 - migrated Application Insights

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -11,40 +11,40 @@ resource "azurerm_resource_group" "rg" {
 
 module "key-vault" {
   source              = "git@github.com:hmcts/cnp-module-key-vault?ref=master"
-  product             = "${var.product}"
-  env                 = "${var.env}"
-  tenant_id           = "${var.tenant_id}"
-  object_id           = "${var.jenkins_AAD_objectId}"
-  resource_group_name = "${azurerm_resource_group.rg.name}"
+  product             = var.product
+  env                 = var.env
+  tenant_id           = var.tenant_id
+  object_id           = var.jenkins_AAD_objectId
+  resource_group_name = azurerm_resource_group.rg.name
 
   # dcd_cc-dev group object ID
-  product_group_object_id    = "38f9dea6-e861-4a50-9e73-21e64f563537"
-  common_tags                = "${var.common_tags}"
-  create_managed_identity    = true
+  product_group_object_id              = "38f9dea6-e861-4a50-9e73-21e64f563537"
+  common_tags                          = var.common_tags
+  create_managed_identity              = true
   additional_managed_identities_access = var.additional_managed_identities_access
 }
 
 resource "azurerm_key_vault_secret" "AZURE_APPINSGHTS_KEY" {
   name         = "AppInsightsInstrumentationKey"
-  value        = azurerm_application_insights.appinsights.instrumentation_key
+  value        = module.application_insights.instrumentation_key
   key_vault_id = module.key-vault.key_vault_id
 }
 
-resource "azurerm_application_insights" "appinsights" {
-  name                = "${var.product}-${var.env}"
-  location            = var.location
+module "application_insights" {
+  source = "git@github.com:hmcts/terraform-module-application-insights?ref=main"
+
+  env      = var.env
+  product  = var.product
+  location = var.location
+
   resource_group_name = azurerm_resource_group.rg.name
-  application_type    = "web"
 
-  tags = var.common_tags
+  common_tags = var.common_tags
+}
 
-  lifecycle {
-    ignore_changes = [
-      # Ignore changes to appinsights as otherwise upgrading to the Azure provider 2.x
-      # destroys and re-creates this appinsights instance
-      application_type,
-    ]
-  }
+moved {
+  from = azurerm_application_insights.appinsights
+  to   = module.application_insights.azurerm_application_insights.this
 }
 
 data "azurerm_key_vault" "s2s_vault" {
@@ -53,7 +53,7 @@ data "azurerm_key_vault" "s2s_vault" {
 }
 data "azurerm_key_vault_secret" "manage-case-s2s-vault-secret" {
   name         = "microservicekey-aac-manage-case-assignment"
-  key_vault_id = "${data.azurerm_key_vault.s2s_vault.id}"
+  key_vault_id = data.azurerm_key_vault.s2s_vault.id
 }
 
 resource "azurerm_key_vault_secret" "aac-manage-case-s2s-secret" {


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15909

### Change description ###
Updating azurerm_application_insights resource and replacing it with module terraform-module-application-insights

This will allow us to migrate Classic Application Insights using https://github.com/hmcts/app-insights-migration-tool as Classic Application Insights will deprecated and will be retired in February 2024.