### PR TITLE
CCD-5160 : Fix CVE-2023-35116 : bumped jackson.version to 2.16.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 ext['spring-security.version'] = '5.6.9'
 ext['spring-framework.version'] = '5.3.27'
 ext['log4j2.version'] = '2.17.1'
-ext['jackson.version'] = '2.15.3'
+ext['jackson.version'] = '2.16.0'
 ext['snakeyaml.version'] = '2.0'
 
 group = 'uk.gov.hmcts.reform'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -2,10 +2,8 @@
   <suppress>
     <notes>Temporary Suppression
         CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
-        CVE-2023-2976  refer [Ticket]
         CVE-2023-34036 refer [Ticket]
         CVE-2023-34034 refer [Ticket]
-        CVE-2023-34040 refer [Ticket]
         CVE-2023-41080 refer [Ticket]
         CVE-2023-42794 refer [Ticket]
         CVE-2023-42795 refer [Ticket]
@@ -15,7 +13,7 @@
         CVE-2023-31582 refer [Ticket]
         CVE-2023-34055 refer [Ticket]
         CVE-2023-46589 refer [Ticket]
-        CVE-2023-35116 refer [Ticket]</notes>
+    </notes>
     <cve>CVE-2022-45688</cve>
     <cve>CVE-2023-34036</cve>
     <cve>CVE-2023-34034</cve>
@@ -28,6 +26,5 @@
     <cve>CVE-2023-31582</cve>
     <cve>CVE-2023-34055</cve>
     <cve>CVE-2023-46589</cve>
-    <cve>CVE-2023-35116</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-5160
CCD-5160 : Fix CVE-2023-35116 : bumped jackson.version to 2.16.0

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
