### PR TITLE
Fix CVE-2023-34034 : bump spring-security.version to 5.7.11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
   id 'au.com.dius.pact' version '4.1.7'
 }
 
-ext['spring-security.version'] = '5.6.9'
+ext['spring-security.version'] = '5.7.11'
 ext['spring-framework.version'] = '5.3.27'
 ext['log4j2.version'] = '2.17.1'
 ext['jackson.version'] = '2.15.3'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,33 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
+        CVE-2023-35116 refer [Ticket]
+        CVE-2023-31582 refer [Ticket]
         CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
-        CVE-2023-2976  refer [Ticket]
+        CVE-2023-5072 refer [Ticket]
+        CVE-2023-34055 refer [Ticket]
         CVE-2023-34036 refer [Ticket]
-        CVE-2023-34034 refer [Ticket]
-        CVE-2023-34040 refer [Ticket]
+        CVE-2023-44487 refer [Ticket]
+        CVE-2023-46589 refer [Ticket]
         CVE-2023-41080 refer [Ticket]
         CVE-2023-42794 refer [Ticket]
         CVE-2023-42795 refer [Ticket]
-        CVE-2023-45648 refer [Ticket]
-        CVE-2023-44487 refer [Ticket]
-        CVE-2023-5072  refer [Ticket]
-        CVE-2023-31582 refer [Ticket]
-        CVE-2023-34055 refer [Ticket]
-        CVE-2023-46589 refer [Ticket]
-        CVE-2023-35116 refer [Ticket]</notes>
+        CVE-2023-45648 refer [Ticket]</notes>
+    <cve>CVE-2023-35116</cve>
+    <cve>CVE-2023-31582</cve>
     <cve>CVE-2022-45688</cve>
+    <cve>CVE-2023-5072</cve>
+    <cve>CVE-2023-34055</cve>
     <cve>CVE-2023-34036</cve>
-    <cve>CVE-2023-34034</cve>
+    <cve>CVE-2023-44487</cve>
+    <cve>CVE-2023-46589</cve>
     <cve>CVE-2023-41080</cve>
     <cve>CVE-2023-42794</cve>
     <cve>CVE-2023-42795</cve>
     <cve>CVE-2023-45648</cve>
-    <cve>CVE-2023-44487</cve>
-    <cve>CVE-2023-5072</cve>
-    <cve>CVE-2023-31582</cve>
-    <cve>CVE-2023-34055</cve>
-    <cve>CVE-2023-46589</cve>
-    <cve>CVE-2023-35116</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-5185
Fix CVE-2023-34034 : bump spring-security.version to 5.7.11

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
