### PR TITLE
Fix CVE-2023-41080 : Update org.apache.tomcat.embed to 9.0.82

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -244,7 +244,7 @@ dependencyManagement {
     }
 
     // CVE-2021-23181
-    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.75') {
+    dependencySet(group: 'org.apache.tomcat.embed', version: '9.0.82') {
       entry 'tomcat-embed-core'
       entry 'tomcat-embed-el'
       entry 'tomcat-embed-websocket'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,33 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?><suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
   <suppress>
     <notes>Temporary Suppression
-        CVE-2022-45688 refer https://tools.hmcts.net/jira/browse/CCD-4373
-        CVE-2023-2976  refer [Ticket]
+        CVE-2023-35116 refer [Ticket]
+        CVE-2023-31582 refer [Ticket]
+        CVE-2022-45688 refer [Ticket]
+        CVE-2023-5072 refer [Ticket]
+        CVE-2023-34055 refer [Ticket]
         CVE-2023-34036 refer [Ticket]
         CVE-2023-34034 refer [Ticket]
-        CVE-2023-34040 refer [Ticket]
-        CVE-2023-41080 refer [Ticket]
-        CVE-2023-42794 refer [Ticket]
-        CVE-2023-42795 refer [Ticket]
-        CVE-2023-45648 refer [Ticket]
-        CVE-2023-44487 refer [Ticket]
-        CVE-2023-5072  refer [Ticket]
-        CVE-2023-31582 refer [Ticket]
-        CVE-2023-34055 refer [Ticket]
-        CVE-2023-46589 refer [Ticket]
-        CVE-2023-35116 refer [Ticket]</notes>
+        CVE-2023-46589 refer [Ticket]</notes>
+    <cve>CVE-2023-35116</cve>
+    <cve>CVE-2023-31582</cve>
     <cve>CVE-2022-45688</cve>
+    <cve>CVE-2023-5072</cve>
+    <cve>CVE-2023-34055</cve>
     <cve>CVE-2023-34036</cve>
     <cve>CVE-2023-34034</cve>
-    <cve>CVE-2023-41080</cve>
-    <cve>CVE-2023-42794</cve>
-    <cve>CVE-2023-42795</cve>
-    <cve>CVE-2023-45648</cve>
-    <cve>CVE-2023-44487</cve>
-    <cve>CVE-2023-5072</cve>
-    <cve>CVE-2023-31582</cve>
-    <cve>CVE-2023-34055</cve>
     <cve>CVE-2023-46589</cve>
-    <cve>CVE-2023-35116</cve>
   </suppress>
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/CCD-4972
Fix CVE-2023-41080 : Update org.apache.tomcat.embed to 9.0.82


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
