### PR TITLE
Update java chart dependency

### DIFF
--- a/charts/aac-manage-case-assignment/Chart.yaml
+++ b/charts/aac-manage-case-assignment/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
   - name: HMCTS CDM team
 dependencies:
   - name: java
-    version: 5.0.5
+    version: 5.0.4
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/

--- a/charts/aac-manage-case-assignment/Chart.yaml
+++ b/charts/aac-manage-case-assignment/Chart.yaml
@@ -3,10 +3,10 @@ appVersion: "1.0"
 description: A Helm chart for manage-case-assignment App
 name: aac-manage-case-assignment
 home: https://github.com/hmcts/aac-manage-case-assignment
-version: 0.2.13
+version: 0.2.14
 maintainers:
   - name: HMCTS CDM team
 dependencies:
   - name: java
-    version: 5.0.0
+    version: 5.0.5
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/


### PR DESCRIPTION
Will stop downstream apps relying on this being stuck by this fixed bug https://github.com/hmcts/chart-library/pull/118/files which was released in 5.0.4 of java




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
