### PR TITLE
CCD-6752 :: Bump com.github.hmcts:service-auth-provider-java-client to version 5.3.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -326,7 +326,7 @@ dependencies {
 
   // HMCTS
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.4'
-  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.2.0'
+  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.3'
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: reformLogging
   implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: reformLogging
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CCD-6752

### Change description ###

CCD-6752 :: Bump com.github.hmcts:service-auth-provider-java-client to version 5.3.3

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
